### PR TITLE
feat: 유저 엔티티 초안 작성

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,5 +13,19 @@ services:
     volumes:
       - db_data:/var/lib/postgresql/data
 
+  pgadmin:
+    image: dpage/pgadmin4:latest
+    restart: always
+    ports:
+      - '8080:80'
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@admin.com
+      PGADMIN_DEFAULT_PASSWORD: admin
+    depends_on:
+      - db
+    volumes:
+      - pgadmin_data:/var/lib/pgadmin
+
 volumes:
   db_data:
+  pgadmin_data:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,12 @@
     "start": "node dist/index.js",
     "docker:up": "docker compose up -d",
     "docker:down": "docker compose down --volumes",
-    "docker:clean": "docker compose down --volumes --rmi all --remove-orphans"
+    "docker:clean": "docker compose down --volumes --rmi all --remove-orphans",
+    "typeorm": "typeorm-ts-node-commonjs -d src/config/data-source.ts",
+    "migration:generate": "npm run typeorm migration:generate src/migrations/AutoMigration",
+    "migration:create": "npm run typeorm migration:create src/migrations/ManualMigration",
+    "migration:run": "npm run typeorm migration:run",
+    "migration:revert": "npm run typeorm migration:revert"
   },
   "repository": {
     "type": "git",

--- a/src/entities/apartment.entity.ts
+++ b/src/entities/apartment.entity.ts
@@ -1,0 +1,56 @@
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import { User } from './user.entity';
+
+@Entity('apartments')
+export class Apartment {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column()
+  apartmentName!: string;
+
+  @Column()
+  apartmentAddress!: string;
+
+  @Column({ unique: true })
+  apartmentManagementNumber!: string;
+
+  @Column({ nullable: true })
+  description!: string;
+
+  @Column({ nullable: true })
+  startComplexNumber!: string;
+
+  @Column({ nullable: true })
+  endComplexNumber!: string;
+
+  @Column({ nullable: true })
+  startDongNumber!: string;
+
+  @Column({ nullable: true })
+  endDongNumber!: string;
+
+  @Column({ nullable: true })
+  startFloorNumber!: string;
+
+  @Column({ nullable: true })
+  endFloorNumber!: string;
+
+  @Column({ nullable: true })
+  startHoNumber!: string;
+
+  @Column({ nullable: true })
+  endHoNumber!: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  imageUrl?: string | null;
+
+  @OneToMany(() => User, (user) => user.apartment)
+  users!: User[];
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+}

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -1,0 +1,73 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import { Apartment } from './apartment.entity';
+
+export enum UserRole {
+  USER = 'USER',
+  ADMIN = 'ADMIN',
+  SUPER_ADMIN = 'SUPER_ADMIN',
+}
+
+export enum JoinStatus {
+  PENDING = 'PENDING',
+  APPROVED = 'APPROVED',
+  REJECTED = 'REJECTED',
+}
+
+@Entity('users')
+export class User {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ unique: true })
+  username!: string;
+
+  @Column()
+  password!: string;
+
+  @Column()
+  contact!: string;
+
+  @Column()
+  name!: string;
+
+  @Column({ unique: true })
+  email!: string;
+
+  @Column({
+    type: 'enum',
+    enum: UserRole,
+    default: UserRole.USER,
+  })
+  role!: UserRole;
+
+  @Column({
+    type: 'enum',
+    enum: JoinStatus,
+    default: JoinStatus.PENDING,
+  })
+  joinStatus!: JoinStatus;
+
+  @Column({ default: true })
+  isActive!: boolean;
+
+  @Column({ nullable: true })
+  apartmentDong!: string;
+
+  @Column({ nullable: true })
+  apartmentHo!: string;
+
+  @ManyToOne(() => Apartment, (apartment) => apartment.users, {
+    nullable: true,
+    onDelete: 'SET NULL',
+  })
+  apartment!: Apartment;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  avatarUrl?: string | null;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+}

--- a/src/migrations/1758096320642-AutoMigration.ts
+++ b/src/migrations/1758096320642-AutoMigration.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AutoMigration1758096320642 implements MigrationInterface {
+    name = 'AutoMigration1758096320642'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TYPE "public"."users_role_enum" AS ENUM('USER', 'ADMIN', 'SUPER_ADMIN')`);
+        await queryRunner.query(`CREATE TYPE "public"."users_joinstatus_enum" AS ENUM('PENDING', 'APPROVED', 'REJECTED')`);
+        await queryRunner.query(`CREATE TABLE "users" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "username" character varying NOT NULL, "password" character varying NOT NULL, "contact" character varying NOT NULL, "name" character varying NOT NULL, "email" character varying NOT NULL, "role" "public"."users_role_enum" NOT NULL DEFAULT 'USER', "joinStatus" "public"."users_joinstatus_enum" NOT NULL DEFAULT 'PENDING', "isActive" boolean NOT NULL DEFAULT true, "apartmentDong" character varying, "apartmentHo" character varying, "avatarUrl" character varying(255), "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "apartmentId" uuid, CONSTRAINT "UQ_fe0bb3f6520ee0469504521e710" UNIQUE ("username"), CONSTRAINT "UQ_97672ac88f789774dd47f7c8be3" UNIQUE ("email"), CONSTRAINT "PK_a3ffb1c0c8416b9fc6f907b7433" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE TABLE "apartments" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "apartmentName" character varying NOT NULL, "apartmentAddress" character varying NOT NULL, "apartmentManagementNumber" character varying NOT NULL, "description" character varying, "startComplexNumber" character varying, "endComplexNumber" character varying, "startDongNumber" character varying, "endDongNumber" character varying, "startFloorNumber" character varying, "endFloorNumber" character varying, "startHoNumber" character varying, "endHoNumber" character varying, "imageUrl" character varying(255), "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "UQ_fefde8b9a2f8b57f3762e449638" UNIQUE ("apartmentManagementNumber"), CONSTRAINT "PK_f6058e85d6d715dbe22b72fe722" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`ALTER TABLE "users" ADD CONSTRAINT "FK_108456969a2cb5d24d7f2541049" FOREIGN KEY ("apartmentId") REFERENCES "apartments"("id") ON DELETE SET NULL ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "users" DROP CONSTRAINT "FK_108456969a2cb5d24d7f2541049"`);
+        await queryRunner.query(`DROP TABLE "apartments"`);
+        await queryRunner.query(`DROP TABLE "users"`);
+        await queryRunner.query(`DROP TYPE "public"."users_joinstatus_enum"`);
+        await queryRunner.query(`DROP TYPE "public"."users_role_enum"`);
+    }
+
+}

--- a/src/migrations/1758096383695-AutoMigration.ts
+++ b/src/migrations/1758096383695-AutoMigration.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AutoMigration1758096383695 implements MigrationInterface {
+    name = 'AutoMigration1758096383695'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "apartments" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "apartmentName" character varying NOT NULL, "apartmentAddress" character varying NOT NULL, "apartmentManagementNumber" character varying NOT NULL, "description" character varying, "startComplexNumber" character varying, "endComplexNumber" character varying, "startDongNumber" character varying, "endDongNumber" character varying, "startFloorNumber" character varying, "endFloorNumber" character varying, "startHoNumber" character varying, "endHoNumber" character varying, "imageUrl" character varying(255), "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "UQ_fefde8b9a2f8b57f3762e449638" UNIQUE ("apartmentManagementNumber"), CONSTRAINT "PK_f6058e85d6d715dbe22b72fe722" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE TYPE "public"."users_role_enum" AS ENUM('USER', 'ADMIN', 'SUPER_ADMIN')`);
+        await queryRunner.query(`CREATE TYPE "public"."users_joinstatus_enum" AS ENUM('PENDING', 'APPROVED', 'REJECTED')`);
+        await queryRunner.query(`CREATE TABLE "users" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "username" character varying NOT NULL, "password" character varying NOT NULL, "contact" character varying NOT NULL, "name" character varying NOT NULL, "email" character varying NOT NULL, "role" "public"."users_role_enum" NOT NULL DEFAULT 'USER', "joinStatus" "public"."users_joinstatus_enum" NOT NULL DEFAULT 'PENDING', "isActive" boolean NOT NULL DEFAULT true, "apartmentDong" character varying, "apartmentHo" character varying, "avatarUrl" character varying(255), "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "apartmentId" uuid, CONSTRAINT "UQ_fe0bb3f6520ee0469504521e710" UNIQUE ("username"), CONSTRAINT "UQ_97672ac88f789774dd47f7c8be3" UNIQUE ("email"), CONSTRAINT "PK_a3ffb1c0c8416b9fc6f907b7433" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`ALTER TABLE "users" ADD CONSTRAINT "FK_108456969a2cb5d24d7f2541049" FOREIGN KEY ("apartmentId") REFERENCES "apartments"("id") ON DELETE SET NULL ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "users" DROP CONSTRAINT "FK_108456969a2cb5d24d7f2541049"`);
+        await queryRunner.query(`DROP TABLE "users"`);
+        await queryRunner.query(`DROP TYPE "public"."users_joinstatus_enum"`);
+        await queryRunner.query(`DROP TYPE "public"."users_role_enum"`);
+        await queryRunner.query(`DROP TABLE "apartments"`);
+    }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
Closes #9

## 📝작업 내용

### 인증 관련 엔티티 작업(유저, 아파트)
user 가 apartment 와 연관이 깊어서 임시로 apartment 초안도 같이 작업이 되었습니다.

- user.entity.ts
- apartment.entity.ts

다른 연관 API 를 바탕으로 수정되거나 추가되어야 하는 부분이 있을 수 있습니다.
특히 Apartment 는 어떤 곳들에서 사용되는지 아직 완벽히 파악하지 못했습니다. 

수정사항이 발생하면 꼭 멘션 부탁드립니다.

### entities, migrations  폴더 위치
entities 는 한 곳에 모으는 것으로 일단 작업이 되어있습니다. typeorm 은 CLI 로 동작하는데, 한 디렉토리 안에 있는게 관리가 편하겠더라구요.ㅠㅠ

### package.json 스크립트 추가
```json
"typeorm": "typeorm-ts-node-commonjs -d src/config/data-source.ts",
"migration:generate": "npm run typeorm migration:generate src/migrations/AutoMigration",
"migration:create": "npm run typeorm migration:create src/migrations/ManualMigration",
"migration:run": "npm run typeorm migration:run",
"migration:revert": "npm run typeorm migration:revert"
```

### pgadmin 추가
docker-compose 에 pgadmin 이 추가되었습니다.
이제 `localhost:8080` 으로 접속할 수 있습니다.

계정 정보는 docker-compose 에 있습니다.

## 💡테스트 결과
<img width="1914" height="961" alt="스크린샷 2025-09-17 오후 5 08 39" src="https://github.com/user-attachments/assets/a377ac5e-e11c-4afc-9389-6bbce4aeac99" />
