### PR TITLE
feat: signup,login,logout,refresh API 초안 구현

### DIFF
--- a/src/auth/auth.dto.ts
+++ b/src/auth/auth.dto.ts
@@ -1,47 +1,233 @@
 import { z } from 'zod';
+import { JoinStatus, UserRole } from '../entities/user.entity';
 
-const RoleEnum = z.enum(['USER', 'ADMIN', 'SUPER_ADMIN']);
-const JoinStatusEnum = z.enum(['PENDING', 'APPROVED', 'REJECTED']);
+// =============================
+// : ZOD CUSTOM TYPES
+// =============================
+const id = z.uuid();
+const email = z.email();
+const username = z.string().min(3).max(128);
+const password = z
+  .string()
+  .min(8)
+  .max(128)
+  .regex(/^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*(),.?":{}|<>]).{8,128}$/, {
+    message: '비밀번호는 영문, 숫자, 특수문자를 모두 포함해야 합니다.',
+  });
+const name = z.string().min(1).max(64);
+const contact = z.string().max(11);
+const role = z.enum(UserRole);
+const joinStatus = z.enum(JoinStatus);
+const apartmentName = z.string().min(1).max(64);
+const apartmentDong = z.string().min(1).max(8);
+const apartmentHo = z.string().min(1).max(8);
+const isActive = z.boolean();
+const description = z.string().min(1).max(256);
+const avatar = z.url().nullable();
+const startComplexNumber = z.number().int().min(1).max(999);
+const endComplexNumber = z.number().int().min(1).max(999);
+const startDongNumber = z.number().int().min(1).max(999);
+const endDongNumber = z.number().int().min(1).max(999);
+const startFloorNumber = z.number().int().min(1).max(999);
+const endFloorNumber = z.number().int().min(1).max(999);
+const startHoNumber = z.number().int().min(1).max(999);
+const endHoNumber = z.number().int().min(1).max(999);
+const apartmentAddress = z.string().min(1).max(512);
+const apartmentManagementNumber = z.string().min(1).max(11);
+const apartmentId = z.uuid().nullable();
+const residentDong = z.string().min(1).max(8).nullable();
+const boardIds = z.object({
+  COMPLAINT: z.uuid(),
+  NOTICE: z.uuid(),
+  POLL: z.uuid(),
+});
+const message = z.string().min(1).max(128);
+const user = z.object({ id: id, role: role });
+
+// =============================
+// : ZOD SCHEMAS
+// =============================
+
+export const AuthRequestParamsSchema = z.object({
+  id: id,
+});
+
+export const SignupRequestBodySchema = z.object({
+  username: username,
+  password: password,
+  contact: contact,
+  name: name,
+  email: email,
+  role: role.default(UserRole.USER),
+  apartmentName: apartmentName,
+  apartmentDong: apartmentDong,
+  apartmentHo: apartmentHo,
+});
 
 export const SignupRequestSchema = z.object({
-  username: z.string().min(3).max(128),
-  password: z.string().min(8).max(128),
-  contact: z.string().min(10).max(11),
-  name: z.string().min(1).max(32),
-  email: z.email().min(5).max(254),
-  role: RoleEnum.default('USER'),
-  apartmentName: z.string().min(1).max(64),
-  apartmentDong: z.string().min(1).max(8),
-  apartmentHo: z.string().min(1).max(8),
+  body: SignupRequestBodySchema,
 });
 
 export const SignupResponseSchema = z.object({
-  id: z.uuid(),
-  email: z.email().min(5).max(254),
-  role: RoleEnum,
-  joinStatus: JoinStatusEnum,
-  isActive: z.boolean(),
+  id: id,
+  name: name,
+  email: email,
+  role: role,
+  joinStatus: joinStatus,
+  isActive: isActive,
+});
+
+export const SignupAdminRequestBodySchema = z.object({
+  username: username,
+  password: password,
+  contact: contact,
+  name: name,
+  email: email,
+  role: role.default(UserRole.ADMIN),
+  description: description,
+  startComplexNumber: startComplexNumber,
+  endComplexNumber: endComplexNumber,
+  startDongNumber: startDongNumber,
+  endDongNumber: endDongNumber,
+  startFloorNumber: startFloorNumber,
+  endFloorNumber: endFloorNumber,
+  startHoNumber: startHoNumber,
+  endHoNumber: endHoNumber,
+  apartmentName: apartmentName,
+  apartmentAddress: apartmentAddress,
+  apartmentManagementNumber: apartmentManagementNumber,
 });
 
 export const SignupAdminRequestSchema = z.object({
-  username: z.string().min(3).max(128),
-  password: z.string().min(8).max(128),
-  contact: z.string().min(10).max(11),
-  name: z.string().min(1).max(32),
-  email: z.email().min(5).max(254),
-  role: RoleEnum.default('ADMIN'),
-  description: z.string().min(1).max(256),
-  startComplexNumber: z.number().int().min(1).max(9999),
-  endComplexNumber: z.number().int().min(1).max(9999),
+  body: SignupAdminRequestBodySchema,
 });
 
-export const SignupAdminResponseSchema = z.object({});
+export const SignupAdminResponseSchema = z.object({
+  id: id,
+  name: name,
+  email: email,
+  role: role,
+  joinStatus: joinStatus,
+  isActive: isActive,
+});
+
+export const SignupSuperAdminRequestBodySchema = z.object({
+  username: username,
+  password: password,
+  contact: contact,
+  name: name,
+  email: email,
+  role: role.default(UserRole.SUPER_ADMIN),
+  joinStatus: joinStatus.default(JoinStatus.APPROVED),
+});
 
 export const SignupSuperAdminRequestSchema = z.object({
-  username: z.string().min(3).max(128),
-  password: z.string().min(8).max(128),
-  contact: z.string().min(10).max(11),
-  name: z.string().min(1).max(32),
-  email: z.email().min(5).max(254),
-  role: RoleEnum.default('SUPER_ADMIN'),
+  body: SignupSuperAdminRequestBodySchema,
+});
+
+export const SignupSuperAdminResponseSchema = z.object({
+  id: id,
+  name: name,
+  email: email,
+  role: role,
+  joinStatus: joinStatus,
+  isActive: isActive,
+});
+
+export const LoginRequestBodySchema = z.object({
+  username: username,
+  password: password,
+});
+
+export const LoginRequestSchema = z.object({
+  body: LoginRequestBodySchema,
+});
+
+export const LoginResponseSchema = z.object({
+  id: id,
+  name: name,
+  email: email,
+  role: role,
+  joinStatus: joinStatus,
+  isActive: isActive,
+  apartmentId: apartmentId,
+  apartmentName: apartmentName,
+  residentDong: residentDong,
+  boardIds: boardIds,
+  username: username,
+  contact: contact,
+  avatar: avatar,
+});
+
+export const LogoutRequestSchema = z.object({
+  user: user,
+});
+
+export const LogoutResponseSchema = z.object({});
+
+export const RefreshRequestSchema = z.object({
+  user: user,
+});
+
+export const RefreshResponseSchema = z.object({
+  message: message,
+});
+
+export const UpdateAdminStatusRequestSchema = z.object({
+  status: joinStatus,
+});
+
+export const UpdateAdminStatusResponseSchema = z.object({
+  message: message,
+});
+
+export const UpdateAdminsStatusRequestSchema = z.object({
+  status: joinStatus,
+});
+
+export const UpdateAdminsStatusResponseSchema = z.object({
+  message: message,
+});
+
+export const UpdateResidentStatusRequestSchema = z.object({
+  status: joinStatus,
+});
+
+export const UpdateResidentStatusResponseSchema = z.object({
+  message: message,
+});
+
+export const UpdateResidentsStatusRequestSchema = z.object({
+  status: joinStatus,
+});
+
+export const UpdateResidentsStatusResponseSchema = z.object({
+  message: z.string().min(1).max(128),
+});
+
+export const UpdateAdminRequestSchema = z.object({
+  contact: contact.optional(),
+  email: email.optional(),
+  description: description.optional(),
+  apartmentName: apartmentName.optional(),
+  apartmentAddress: apartmentAddress.optional(),
+  apartmentManagementNumber: apartmentManagementNumber.optional(),
+});
+
+export const UpdateAdminResponseSchema = z.object({
+  message: message,
+});
+
+export const DeleteAdminRequestSchema = z.object({
+  params: AuthRequestParamsSchema,
+});
+
+export const DeleteAdminResponseSchema = z.object({
+  message: message,
+});
+
+export const CleanupRequestSchema = z.object({});
+
+export const CleanupResponseSchema = z.object({
+  message: message,
 });

--- a/src/auth/auth.router.ts
+++ b/src/auth/auth.router.ts
@@ -1,23 +1,19 @@
 import express from 'express';
 import { allow, AllowedRole } from '../middlewares/allow.middleware';
 import {
-  handleApproveAdmin,
-  handleApproveAdmins,
-  handleApproveUser,
-  handleApproveUsers,
   handleCleanup,
   handleDeleteAdmin,
   handleLogin,
   handleLogout,
   handleRefresh,
-  handleRejectAdmin,
-  handleRejectAdmins,
-  handleRejectUser,
-  handleRejectUsers,
   handleSignup,
   handleSignupAdmin,
   handleSignupSuperAdmin,
   handleUpdateAdmin,
+  handleUpdateAdminsStatus,
+  handleUpdateAdminStatus,
+  handleUpdateResidentsStatus,
+  handleUpdateResidentStatus,
 } from './auth.controller';
 
 const auth = express.Router();
@@ -28,16 +24,12 @@ auth.post('/signup/super-admin', allow(AllowedRole.NONE), handleSignupSuperAdmin
 auth.post('/login', allow(AllowedRole.NONE), handleLogin);
 auth.post('/logout', allow(AllowedRole.USER), handleLogout);
 auth.post('/refresh', allow(AllowedRole.USER), handleRefresh);
-auth.post('/approve-admin', allow(AllowedRole.SUPER_ADMIN), handleApproveAdmin);
-auth.post('/reject-admin', allow(AllowedRole.SUPER_ADMIN), handleRejectAdmin);
-auth.post('/approve-admins', allow(AllowedRole.SUPER_ADMIN), handleApproveAdmins);
-auth.post('/reject-admins', allow(AllowedRole.SUPER_ADMIN), handleRejectAdmins);
-auth.post('/approve-user/:residentId', allow(AllowedRole.ADMIN), handleApproveUser);
-auth.post('/reject-user/:residentId', allow(AllowedRole.ADMIN), handleRejectUser);
-auth.post('/approve-users', allow(AllowedRole.ADMIN), handleApproveUsers);
-auth.post('/reject-users', allow(AllowedRole.ADMIN), handleRejectUsers);
-auth.patch('/update-admin', allow(AllowedRole.SUPER_ADMIN), handleUpdateAdmin); // [!] id 가 body 에 들어가서 처리됨.
-auth.patch('/delete-admin/:adminId', allow(AllowedRole.SUPER_ADMIN), handleDeleteAdmin);
-auth.post('/cleanup', allow(AllowedRole.SUPER_ADMIN), handleCleanup);
+auth.patch('/admins/:id/status', allow(AllowedRole.SUPER_ADMIN), handleUpdateAdminStatus);
+auth.patch('/admins/status', allow(AllowedRole.SUPER_ADMIN), handleUpdateAdminsStatus);
+auth.patch('/residents/:id/status', allow(AllowedRole.ADMIN), handleUpdateResidentStatus);
+auth.patch('/residents/status', allow(AllowedRole.ADMIN), handleUpdateResidentsStatus);
+auth.patch('/admins/:id', allow(AllowedRole.SUPER_ADMIN), handleUpdateAdmin);
+auth.delete('/admins/:id', allow(AllowedRole.SUPER_ADMIN), handleDeleteAdmin);
+auth.post('/cleanup', allow(AllowedRole.ADMIN), handleCleanup);
 
 export default auth;

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,1 +1,314 @@
-export const signup = async () => {};
+import z from 'zod';
+import {
+  LoginRequestBodySchema,
+  SignupAdminRequestBodySchema,
+  SignupRequestBodySchema,
+  SignupSuperAdminRequestBodySchema,
+} from './auth.dto';
+import { AppDataSource } from '../config/data-source';
+import {
+  BadRequestError,
+  ConflictError,
+  ForbiddenError,
+  InternalServerError,
+  NotFoundError,
+  UnauthorizedError,
+} from '../types/error.type';
+import { JoinStatus, UserRole } from '../entities/user.entity';
+import { HouseholdType, Resident, ResidentStatus } from '../entities/resident.entity';
+import { comparePassword } from '../utils/password.util';
+
+// ============================
+// : REPOSITORIES
+// ============================
+const userRepository = AppDataSource.getRepository('User');
+const apartmentRepository = AppDataSource.getRepository('Apartment');
+const residentRepository = AppDataSource.getRepository('Resident');
+const complaintBoardRepository = AppDataSource.getRepository('ComplaintBoard');
+const noticeBoardRepository = AppDataSource.getRepository('NoticeBoard');
+const pollBoardRepository = AppDataSource.getRepository('PollBoard');
+
+// ============================
+// : SERVICE FUNCTIONS
+// ============================
+
+// SIGNUP(USER)
+export const signup = async (body: z.infer<typeof SignupRequestBodySchema>) => {
+  const { username, password, contact, name, email, role, apartmentName, apartmentDong, apartmentHo } = body;
+
+  // 이미 사용 중인 username, email, contact 인지 확인
+  const existUser = await userRepository.findOne({
+    where: [{ username }, { email }, { contact }],
+  });
+  if (existUser) {
+    throw new ConflictError('이미 사용 중인 정보(아이디, 이메일, 전화번호)입니다');
+  }
+
+  // 아파트 목록을 서버에서 받아서 id를 가져오기 때문에
+  // 에러가 발생할 경우는 드물지만, 미리 예외 처리
+  const existApartment = await apartmentRepository.findOne({
+    where: { name: apartmentName },
+  });
+  if (!existApartment) {
+    throw new InternalServerError('회원가입을 진행하는 중 오류가 발생했습니다.');
+  }
+  const existApartmentId = existApartment.id;
+
+  // 이미 등록된 입주민이 있는지 확인
+  let resident;
+  let joinStatus = JoinStatus.PENDING;
+  let isRegistered = false;
+  const existResidents = await apartmentRepository.find({
+    where: { residents: { dong: apartmentDong, ho: apartmentHo } },
+    relations: { residents: true },
+  });
+
+  if (existResidents) {
+    // 입주민 정보와 현재 들어온 정보가 일치하는지 확인
+    const isMatch = existResidents.some((resident) => {
+      return resident.residents.some((r: Resident) => r.name === name && r.contact === contact);
+    });
+
+    if (isMatch) {
+      // 기존 입주민과 정보가 일치하면 자동 승인
+      resident = existResidents[0].residents.find((r: Resident) => r.name === name && r.contact === contact);
+      joinStatus = JoinStatus.APPROVED;
+      isRegistered = resident.isRegistered;
+      if (!isRegistered) {
+        // 기존 입주민이 가입한 적이 없는 경우
+        resident.isRegistered = true;
+        await residentRepository.save(resident);
+      }
+    }
+  } else {
+    // 새로운 입주민 등록(승인 필요)
+    resident = residentRepository.create({
+      name: name,
+      contact: contact,
+      dong: apartmentDong,
+      ho: apartmentHo,
+      apartment: existApartment,
+      apartmentId: existApartmentId,
+      isHouseholder: HouseholdType.HOUSEHOLDER, // 가입 시점에는 HOUSEHOLDER 가 기본값
+      residentStatus: ResidentStatus.RESIDENCE, // 가입 시점에는 RESIDENCE 가 기본값
+      isRegistered: true, // 위리브 회원가입으로 생성되기 때문에 자동으로 true 처리
+    });
+    await residentRepository.save(resident);
+  }
+
+  const residentId = resident.id;
+
+  const newUser = userRepository.create({
+    username,
+    password,
+    contact,
+    name,
+    email,
+    apartment: existApartment,
+    apartmentId: existApartmentId,
+    resident,
+    residentId,
+    role: role || UserRole.ADMIN,
+    joinStatus: joinStatus,
+  });
+
+  await userRepository.save(newUser);
+
+  return newUser;
+};
+
+// SIGNUP(ADMIN)
+export const signupAdmin = async (body: z.infer<typeof SignupAdminRequestBodySchema>) => {
+  const {
+    username,
+    password,
+    contact,
+    name,
+    email,
+    description,
+    startComplexNumber,
+    endComplexNumber,
+    startDongNumber,
+    endDongNumber,
+    startFloorNumber,
+    endFloorNumber,
+    startHoNumber,
+    endHoNumber,
+    role,
+    apartmentName,
+    apartmentAddress,
+    apartmentManagementNumber,
+  } = body;
+
+  // 이미 사용 중인 username, email, contact 인지 확인
+  const existUser = await userRepository.findOne({
+    where: [{ username }, { email }, { contact }],
+  });
+  if (existUser) {
+    throw new ConflictError('이미 사용 중인 정보(아이디, 이메일, 전화번호)입니다');
+  }
+
+  let apartment;
+  let apartmentId = '';
+  const existApartment = await apartmentRepository.findOne({
+    where: { name: apartmentName },
+  });
+  if (!existApartment) {
+    // NoticeBoard, ComplaintBoard, PollBoard
+    const newNoticeBoard = noticeBoardRepository.create();
+    await noticeBoardRepository.save(newNoticeBoard);
+    const newComplaintBoard = complaintBoardRepository.create();
+    await complaintBoardRepository.save(newComplaintBoard);
+    const newPollBoard = pollBoardRepository.create();
+    await pollBoardRepository.save(newPollBoard);
+
+    // 새로운 아파트 등록
+    apartment = apartmentRepository.create({
+      name: apartmentName,
+      address: apartmentAddress,
+      officeNumber: apartmentManagementNumber,
+      description: description,
+      startComplexNumber: startComplexNumber,
+      endComplexNumber: endComplexNumber,
+      startDongNumber: startDongNumber,
+      endDongNumber: endDongNumber,
+      startFloorNumber: startFloorNumber,
+      endFloorNumber: endFloorNumber,
+      startHoNumber: startHoNumber,
+      endHoNumber: endHoNumber,
+      noticeBoard: newNoticeBoard,
+      complaintBoard: newComplaintBoard,
+      pollBoard: newPollBoard,
+    });
+    await apartmentRepository.save(apartment);
+    apartmentId = apartment.id;
+  } else {
+    apartment = existApartment;
+    apartmentId = apartment.id;
+  }
+
+  const newAdmin = userRepository.create({
+    username,
+    password,
+    contact,
+    name,
+    email,
+    apartment,
+    apartmentId,
+    role: role || UserRole.ADMIN,
+    joinStatus: JoinStatus.PENDING,
+    isActive: true,
+  });
+
+  await userRepository.save(newAdmin);
+
+  apartment.admins.push(newAdmin);
+
+  await apartmentRepository.save(apartment);
+
+  return newAdmin;
+};
+
+// SIGNUP(SUPER_ADMIN)
+export const signupSuperAdmin = async (body: z.infer<typeof SignupSuperAdminRequestBodySchema>) => {
+  const { username, password, contact, name, email, role, joinStatus } = body;
+
+  // 이미 사용 중인 username, email, contact 인지 확인
+  const existUser = await userRepository.findOne({
+    where: [{ username }, { email }, { contact }],
+  });
+  if (existUser) {
+    throw new ConflictError('이미 사용 중인 정보(아이디, 이메일, 전화번호)입니다');
+  }
+
+  const newSuperAdmin = userRepository.create({
+    username,
+    password,
+    contact,
+    name,
+    email,
+    role: role || UserRole.SUPER_ADMIN,
+    joinStatus: joinStatus || JoinStatus.APPROVED,
+    isActive: true,
+  });
+
+  await userRepository.save(newSuperAdmin);
+
+  return newSuperAdmin;
+};
+
+// LOGIN
+export const login = async (body: z.infer<typeof LoginRequestBodySchema>) => {
+  const { username, password } = body;
+  const user = await userRepository.findOne({
+    where: { username },
+    relations: { apartment: true, resident: true },
+  });
+  if (!user) {
+    throw new BadRequestError('사용자를 찾을 수 없습니다');
+  }
+  const isPasswordMatch = await comparePassword(password, user.password);
+  if (!isPasswordMatch) {
+    throw new UnauthorizedError('인증 실패(잘못된 아이디 또는 비밀번호)');
+  }
+  if (user.joinStatus !== JoinStatus.APPROVED) {
+    throw new ForbiddenError('접근 권한이 없습니다(이미 로그인 상태이거나 비활성화된 계정입니다)');
+  }
+
+  user.lastLoginAt = new Date();
+  await userRepository.save(user);
+
+  return user;
+};
+
+export const addRefreshToken = async (userId: string, refreshToken: string) => {
+  const user = await userRepository.findOne({
+    where: { id: userId },
+  });
+  if (!user) {
+    throw new NotFoundError('존재하지 않는 사용자입니다.');
+  }
+  user.refreshToken = refreshToken;
+  await userRepository.save(user);
+};
+
+// LOGOUT
+// 지금은 별다른 로직이 없습니다.
+// 차후 로그아웃 후 토큰 블랙리스트 처리를 위한 로직이 추가될 경우 대비
+export const logout = async (userId: string) => {
+  const existUser = await userRepository.findOne({
+    where: { id: userId },
+  });
+  if (!existUser) {
+    throw new NotFoundError('존재하지 않는 사용자입니다.');
+  }
+  return;
+};
+
+export const removeRefreshToken = async (userId: string) => {
+  const user = await userRepository.findOne({
+    where: { id: userId },
+  });
+  if (!user) {
+    throw new NotFoundError('존재하지 않는 사용자입니다.');
+  }
+  user.refreshToken = null;
+  await userRepository.save(user);
+  return;
+};
+
+// REFRESH
+export const refresh = async (userId: string, refreshToken: string) => {
+  const user = await userRepository.findOne({
+    where: { id: userId },
+    relations: { apartment: true, resident: true },
+  });
+  if (!user) {
+    throw new NotFoundError('존재하지 않는 사용자입니다.');
+  }
+  if (user.refreshToken !== refreshToken) {
+    throw new UnauthorizedError('갱신 실패(다른 기기에서 로그인하여 토큰이 변경되었거나, 로그아웃하여 토큰이 삭제됨)');
+  }
+
+  return;
+};

--- a/src/entities/apartment.entity.ts
+++ b/src/entities/apartment.entity.ts
@@ -1,8 +1,18 @@
-import { Entity, PrimaryGeneratedColumn, Column, OneToMany, ManyToOne, JoinColumn, OneToOne } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  OneToMany,
+  OneToOne,
+  CreateDateColumn,
+  UpdateDateColumn,
+  DeleteDateColumn,
+} from 'typeorm';
 import { User } from './user.entity';
 import { NoticeBoard } from './notice-board.entity';
 import { ComplaintBoard } from './complaint-board.entity';
 import { PollBoard } from './poll-board.entity';
+import { Resident } from './resident.entity';
 
 // =
 // : 아파트
@@ -65,12 +75,8 @@ export class Apartment {
   @OneToMany(() => User, (user) => user.apartment)
   users!: User[];
 
-  @ManyToOne(() => User)
-  @JoinColumn({ name: 'adminId' })
-  admin!: User;
-
-  @Column()
-  adminId!: string;
+  @OneToMany(() => User, (user) => user.apartment)
+  admins!: User[];
 
   @OneToOne(() => NoticeBoard, (noticeBoard) => noticeBoard.apartment)
   noticeBoard!: NoticeBoard;
@@ -80,4 +86,16 @@ export class Apartment {
 
   @OneToOne(() => PollBoard, (pollBoard) => pollBoard.apartment)
   pollBoard!: PollBoard;
+
+  @OneToMany(() => Resident, (resident) => resident.apartment)
+  residents!: Resident[];
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+
+  @DeleteDateColumn({ nullable: true })
+  deletedAt?: Date;
 }

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -1,4 +1,15 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany, JoinColumn, OneToOne } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  OneToMany,
+  JoinColumn,
+  OneToOne,
+  CreateDateColumn,
+  UpdateDateColumn,
+  DeleteDateColumn,
+} from 'typeorm';
 import { Apartment } from './apartment.entity';
 import { Resident } from './resident.entity';
 import { Complaint } from './complaint.entity';
@@ -34,10 +45,10 @@ export class User {
   @Column()
   name!: string;
 
-  @Column()
+  @Column({ unique: true })
   email!: string;
 
-  @Column()
+  @Column({ unique: true })
   contact!: string;
 
   @Column({ nullable: true })
@@ -64,7 +75,7 @@ export class User {
   apartment?: Apartment;
 
   @Column()
-  apartmentId!: string;
+  apartmentId?: string;
 
   @OneToMany(() => Complaint, (complaint) => complaint.user)
   complaints!: Complaint[];
@@ -80,4 +91,19 @@ export class User {
 
   @OneToMany(() => Comment, (comment) => comment.user)
   comments!: Comment[];
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+
+  @DeleteDateColumn({ nullable: true })
+  deletedAt?: Date;
+
+  @Column({ nullable: true })
+  lastLoginAt?: Date;
+
+  @Column({ nullable: true })
+  refreshToken?: string;
 }

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -13,6 +13,7 @@ import {
 import { Apartment } from './apartment.entity';
 import { Resident } from './resident.entity';
 import { Complaint } from './complaint.entity';
+import { Vote } from './vote.entity';
 
 // =
 // : 사용자

--- a/src/types/payload.type.ts
+++ b/src/types/payload.type.ts
@@ -1,7 +1,6 @@
-import { JwtPayload } from 'jsonwebtoken';
 import { UserRole } from '../entities/user.entity';
 
-export type Payload = JwtPayload & {
+export type Payload = {
   id: string;
   role: UserRole;
 };

--- a/src/utils/token.util.ts
+++ b/src/utils/token.util.ts
@@ -6,16 +6,14 @@ import env from '../config/env';
 
 // ACCESS_TOKEN 생성
 export const generateAccessToken = (payload: Payload): string => {
-  const { _iat, _exp, ...other } = payload;
   const expiresIn = env.JWT_ACCESS_EXPIRATION;
-  return jwt.sign(other, env.JWT_ACCESS_SECRET, { expiresIn });
+  return jwt.sign(payload, env.JWT_ACCESS_SECRET, { expiresIn });
 };
 
 // REFRESH_TOKEN 생성
 export const generateRefreshToken = (payload: Payload): string => {
-  const { _iat, _exp, ...other } = payload;
   const expiresIn = env.JWT_REFRESH_EXPIRATION;
-  return jwt.sign(other, env.JWT_REFRESH_SECRET, { expiresIn });
+  return jwt.sign(payload, env.JWT_REFRESH_SECRET, { expiresIn });
 };
 
 // ACCESS_TOKEN 검증


### PR DESCRIPTION
## #️⃣연관된 이슈
#32

## 📝작업 내용

### Signup API
회원가입 API 는 크게 3가지로 분류됩니다.

- Signup(입주민)
- SIgnupAdmin(관리자)
- SignupSuperAdmin(슈퍼관리자)

### User 의 admin > admins 변경
코드잇 배포 프론트에서 동일한 아파트에 여러 admin 이 가입될 수 있음을 확인했습니다.

기존에 한명의 admin 이었던 것을 admins 로 변경하여 여러 user 를 받아들일 수 있도록 수정했습니다.

### Login API
보안을 위해서 Login 했을 때, refreshToken 을 user 가 저장합니다. 그리고 로그아웃 했을 때 해당 refreshToken 을 삭제합니다.
그래서 refresh 요청이 왔을 때, 해당 refreshToken 과 비교해서 로그인 한 상태인 유저인지 확인해서 refresh 를 진행합니다.
반대로 로그인 된 유저가 아니면, refresh 가 실패합니다.

accessToken 은 15분 밖에 지속이 되지 않기 때문에, 별도로 서버에 저장하지 않습니다.

- Login 이 정상적으로 완료되면 `lastLoginAt` 이 갱신됩니다.
- Login 이 정상적으로 완료되면 `refreshToken` 이 갱신됩니다.

### Logout API

- Logout 이 정상적으로 완료되면 `refreshToken` 이 `null` 이 됩니다.

### Refresh API

- Refresh 가 정상적으로 완료되면 `accessToken`, `refreshToken` 이 갱신됩니다.
- User 에 `refreshToken 이 갱신됩니다.

[!] 프론트 수정본이 올라오는 데로 프론트 연동 테스트 예정입니다.