### PR TITLE
Feat: poll 관련 DTO 및 entity 초안 작성

### DIFF
--- a/src/entities/poll-option.entity.ts
+++ b/src/entities/poll-option.entity.ts
@@ -1,0 +1,32 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  OneToMany,
+  JoinColumn,
+} from "typeorm";
+import { Poll } from "./poll.entity";
+import { Vote } from "./vote.entity";
+
+@Entity("poll_options")
+export class PollOption {
+  @PrimaryGeneratedColumn("uuid")
+  id!: string;
+
+  @Column()
+  title!: string;
+
+  @Column({ default: 0 })
+  voteCount!: number;
+
+  @ManyToOne(() => Poll, (poll) => poll.options, { onDelete: "CASCADE" })
+  @JoinColumn({ name: "pollId" })
+  poll!: Poll;
+
+  @Column()
+  pollId!: string;
+
+  @OneToMany(() => Vote, (vote) => vote.option)
+  votes!: Vote[];
+}

--- a/src/entities/poll.entity.ts
+++ b/src/entities/poll.entity.ts
@@ -59,4 +59,5 @@ export class Poll {
 
   @OneToMany(() => PollOption, (option) => option.poll, { cascade: true })
   options!: PollOption[];
+  pollBoard: any;
 }

--- a/src/entities/poll.entity.ts
+++ b/src/entities/poll.entity.ts
@@ -1,0 +1,62 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  OneToMany,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from "typeorm";
+import { PollOption } from "./poll-option.entity";
+import { User } from "./user.entity";
+
+@Entity("polls")
+export class Poll {
+  @PrimaryGeneratedColumn("uuid")
+  pollId!: string;
+
+  @Column()
+  boardId!: string;
+
+  @ManyToOne(() => User, (user) => user.polls)
+  @JoinColumn({ name: "userId" })
+  user!: User;
+
+  @Column()
+  userId!: string;
+
+  @Column()
+  title!: string;
+
+  @Column("text")
+  content!: string;
+
+  @Column()
+  writerName!: string;
+
+  @Column({ nullable: true })
+  buildingPermission?: string;
+
+  @Column("timestamp")
+  startDate!: Date;
+
+  @Column("timestamp")
+  endDate!: Date;
+
+  @Column({
+    type: "enum",
+    enum: ["IN_PROGRESS", "PENDING", "COMPLETED"],
+    default: "PENDING",
+  })
+  status!: "IN_PROGRESS" | "PENDING" | "COMPLETED";
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+
+  @OneToMany(() => PollOption, (option) => option.poll, { cascade: true })
+  options!: PollOption[];
+}

--- a/src/polls/dto/create-poll.dto.ts
+++ b/src/polls/dto/create-poll.dto.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+export const CreatePollDtoSchema = z.object({
+  boardId: z.string(),
+  status: z.enum(["IN_PROGRESS", "PENDING", "COMPLETED"]),
+  title: z.string().min(1, "제목을 입력해주세요"),
+  content: z.string().min(1, "내용을 입력해주세요"),
+  buildingPermission: z.string().optional(),
+  startDate: z.string().datetime(),
+  endDate: z.string().datetime(),
+  options: z
+    .array(
+      z.object({
+        title: z.string().min(1, "선택지를 입력해주세요"),
+      })
+    )
+    .min(2, "최소 2개의 선택지가 필요합니다"),
+});
+
+export type CreatePollDto = z.infer<typeof CreatePollDtoSchema>;
+
+export const validateCreatePoll = (data: unknown) =>
+  CreatePollDtoSchema.parse(data);

--- a/src/polls/dto/create-poll.dto.ts
+++ b/src/polls/dto/create-poll.dto.ts
@@ -1,13 +1,19 @@
 import { z } from "zod";
 
+const dateTimeSchema = z
+  .string()
+  .refine((val) => !isNaN(Date.parse(val)), {
+    message: "올바른 날짜 형식이 아닙니다 (ISO 8601)",
+  });
+
 export const CreatePollDtoSchema = z.object({
   boardId: z.string(),
   status: z.enum(["IN_PROGRESS", "PENDING", "COMPLETED"]),
   title: z.string().min(1, "제목을 입력해주세요"),
   content: z.string().min(1, "내용을 입력해주세요"),
   buildingPermission: z.string().optional(),
-  startDate: z.string().datetime(),
-  endDate: z.string().datetime(),
+  startDate: dateTimeSchema,
+  endDate: dateTimeSchema,
   options: z
     .array(
       z.object({

--- a/src/polls/dto/option-response.dto.ts
+++ b/src/polls/dto/option-response.dto.ts
@@ -1,0 +1,11 @@
+export interface OptionResponse {
+  id: string;
+  title: string;
+  voteCount: number;
+}
+
+export interface OptionResult {
+  id: string;
+  title: string;
+  votes: number;
+}

--- a/src/polls/dto/poll-detail-response.dto.ts
+++ b/src/polls/dto/poll-detail-response.dto.ts
@@ -1,0 +1,17 @@
+import { OptionResponse } from "./option-response.dto";
+
+export interface PollDetailResponseDto {
+  pollId: string;
+  userId: string;
+  title: string;
+  writerName: string;
+  buildingPermission?: string;
+  createdAt: string;
+  updatedAt: string;
+  startDate: string;
+  endDate: string;
+  status: "IN_PROGRESS" | "PENDING" | "COMPLETED";
+  content: string;
+  boardName: string;
+  options: OptionResponse[];
+}

--- a/src/polls/dto/poll-list-response.dto.ts
+++ b/src/polls/dto/poll-list-response.dto.ts
@@ -1,0 +1,17 @@
+export interface PollListResponseDto {
+  pollId: string;
+  userId: string;
+  title: string;
+  writerName: string;
+  buildingPermission?: string;
+  createdAt: string;
+  updatedAt: string;
+  startDate: string;
+  endDate: string;
+  status: "IN_PROGRESS" | "PENDING" | "COMPLETED";
+}
+
+export interface PollsListWrapperDto {
+  polls: PollListResponseDto[];
+  totalCount: number;
+}

--- a/src/polls/dto/poll-query-params.dto.ts
+++ b/src/polls/dto/poll-query-params.dto.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const PollQueryParamsSchema = z.object({
+  page: z.coerce.number().int().positive().default(1),
+  limit: z.coerce.number().int().positive().max(100).default(11),
+});
+
+export type PollQueryParams = z.infer<typeof PollQueryParamsSchema>;
+
+export const validatePollQuery = (data: unknown) =>
+  PollQueryParamsSchema.parse(data);

--- a/src/polls/dto/poll-scheduler-ping-response.dto.ts
+++ b/src/polls/dto/poll-scheduler-ping-response.dto.ts
@@ -1,0 +1,3 @@
+export interface PollSchedulerPingResponseDto {
+  message: string;
+}

--- a/src/polls/dto/update-poll.dto.ts
+++ b/src/polls/dto/update-poll.dto.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+export const UpdatePollDtoSchema = z.object({
+  userId: z.string(),
+  title: z.string().min(1, "제목을 입력해주세요"),
+  content: z.string().min(1, "내용을 입력해주세요"),
+  buildingPermission: z.string().optional(),
+  startDate: z.string().datetime(),
+  endDate: z.string().datetime(),
+  status: z.enum(["PENDING", "IN_PROGRESS", "COMPLETED"]),
+  options: z
+    .array(
+      z.object({
+        title: z.string().min(1, "선택지를 입력해주세요"),
+      })
+    )
+    .min(2, "최소 2개의 선택지가 필요합니다")
+    .optional(),
+});
+
+export type UpdatePollDto = z.infer<typeof UpdatePollDtoSchema>;
+
+export const validateUpdatePoll = (data: unknown) =>
+  UpdatePollDtoSchema.parse(data);

--- a/src/polls/dto/update-poll.dto.ts
+++ b/src/polls/dto/update-poll.dto.ts
@@ -1,12 +1,18 @@
 import { z } from "zod";
 
+const dateTimeSchema = z
+  .string()
+  .refine((val) => !isNaN(Date.parse(val)), {
+    message: "올바른 날짜 형식이 아닙니다 (ISO 8601)",
+  });
+
 export const UpdatePollDtoSchema = z.object({
   userId: z.string(),
   title: z.string().min(1, "제목을 입력해주세요"),
   content: z.string().min(1, "내용을 입력해주세요"),
   buildingPermission: z.string().optional(),
-  startDate: z.string().datetime(),
-  endDate: z.string().datetime(),
+  startDate: dateTimeSchema,
+  endDate: dateTimeSchema,
   status: z.enum(["PENDING", "IN_PROGRESS", "COMPLETED"]),
   options: z
     .array(


### PR DESCRIPTION
## #️⃣연관된 이슈
#33 
## 📝작업 내용
- poll (투표 관리) 관련 DTO 및 entity 초안 작성
- poll.entity.ts 에서 Board (공지사항 게시판)과의 연결성 필요 (투표 마감 시 자동으로 공지사항으로 등록되어야 함)
 -> board 관련 entity 작성되면 연결 할 예정

- Zod 스키마에서 원래 datetime() 메서드를 사용했는데, 버전 문제로 refine()을 사용한 방법으로 수정
(해결 방법이 Zod 버전을 다운그레이드 하거나 refine() 으로 수정하는 것.) 
## 💡테스트 결과
- board 관련 관계 설정 후 마이그레이션 진행 예정
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
