### PR TITLE
feat: Auth 프론트 테스트 중 발생한 에러 해결을 위한 기능 추가

### DIFF
--- a/src/apartments/apartments.controller.ts
+++ b/src/apartments/apartments.controller.ts
@@ -1,0 +1,26 @@
+import { RequestHandler } from 'express';
+import { GetApartmentRequestSchema, GetApartmentsRequestSchema } from './apartments.dto';
+import { BadRequestError } from '../types/error.type';
+import { getApartment, getApartments } from './apartments.service';
+
+export const handleGetApartments: RequestHandler = async (req, res) => {
+  const result = GetApartmentsRequestSchema.safeParse(req);
+  if (!result.success) {
+    return new BadRequestError('잘못된 요청(필수사항 누락 또는 잘못된 입력값)입니다.');
+  }
+
+  const gotApartments = await getApartments(result.data.query);
+
+  return res.status(200).json(gotApartments);
+};
+
+export const handleGetApartment: RequestHandler = async (req, res) => {
+  const result = GetApartmentRequestSchema.safeParse(req);
+  if (!result.success) {
+    return new BadRequestError('잘못된 요청(필수사항 누락 또는 잘못된 입력값)입니다.');
+  }
+
+  const gotApartment = await getApartment(result.data.params);
+
+  return res.status(200).json(gotApartment);
+};

--- a/src/apartments/apartments.dto.ts
+++ b/src/apartments/apartments.dto.ts
@@ -1,0 +1,88 @@
+import { z } from 'zod';
+import { ApartmentStatus } from '../entities/apartment.entity';
+
+// =============================
+// : ZOD CUSTOM TYPES
+// =============================
+const id = z.uuid();
+const name = z.string().min(1).max(64);
+const address = z.string().min(1).max(512);
+const officeNumber = z.string().min(9).max(11);
+const description = z.string().min(1).max(256);
+const startComplexNumber = z.number().int().min(1).max(999);
+const endComplexNumber = z.number().int().min(1).max(999);
+const startDongNumber = z.number().int().min(1).max(999);
+const endDongNumber = z.number().int().min(1).max(999);
+const startFloorNumber = z.number().int().min(1).max(999);
+const endFloorNumber = z.number().int().min(1).max(999);
+const startHoNumber = z.number().int().min(1).max(999);
+const endHoNumber = z.number().int().min(1).max(999);
+const apartmentStatus = z.enum(ApartmentStatus);
+const adminId = id;
+const adminName = name;
+const adminContact = z.string().min(9).max(11);
+const adminEmail = z.email();
+
+// =============================
+// : ZOD SCHEMAS
+// =============================
+export const ApartmentsRequestParamsSchema = z.object({
+  id: id,
+});
+
+export const GetApartmentsRequestQuerySchema = z.object({
+  name: name,
+  address: address,
+});
+
+export const GetApartmentsRequestSchema = z.object({
+  query: GetApartmentsRequestQuerySchema,
+});
+
+export const GetApartmentsResponseSchema = z.array(
+  z.object({
+    id: id,
+    name: name,
+    address: address,
+    officeNumber: officeNumber,
+    description: description,
+    startComplexNumber: startComplexNumber,
+    endComplexNumber: endComplexNumber,
+    startDongNumber: startDongNumber,
+    endDongNumber: endDongNumber,
+    startFloorNumber: startFloorNumber,
+    endFloorNumber: endFloorNumber,
+    startHoNumber: startHoNumber,
+    endHoNumber: endHoNumber,
+    apartmentStatus: apartmentStatus,
+    adminId: adminId,
+    adminName: adminName,
+    adminContact: adminContact,
+    adminEmail: adminEmail,
+  })
+);
+
+export const GetApartmentRequestSchema = z.object({
+  params: ApartmentsRequestParamsSchema,
+});
+
+export const GetApartmentResponseSchema = z.object({
+  id: id,
+  name: name,
+  address: address,
+  officeNumber: officeNumber,
+  description: description,
+  startComplexNumber: startComplexNumber,
+  endComplexNumber: endComplexNumber,
+  startDongNumber: startDongNumber,
+  endDongNumber: endDongNumber,
+  startFloorNumber: startFloorNumber,
+  endFloorNumber: endFloorNumber,
+  startHoNumber: startHoNumber,
+  endHoNumber: endHoNumber,
+  apartmentStatus: apartmentStatus,
+  adminId: adminId,
+  adminName: adminName,
+  adminContact: adminContact,
+  adminEmail: adminEmail,
+});

--- a/src/apartments/apartments.router.ts
+++ b/src/apartments/apartments.router.ts
@@ -1,0 +1,10 @@
+import Router from 'express';
+import { allow, AllowedRole } from '../middlewares/allow.middleware';
+import { handleGetApartment, handleGetApartments } from './apartments.controller';
+
+const apartments = Router();
+
+apartments.get('/', allow(AllowedRole.NONE), handleGetApartments);
+apartments.get('/:id', allow(AllowedRole.NONE), handleGetApartment);
+
+export default apartments;

--- a/src/apartments/apartments.service.ts
+++ b/src/apartments/apartments.service.ts
@@ -1,0 +1,79 @@
+import z from 'zod';
+import { ApartmentsRequestParamsSchema, GetApartmentsRequestQuerySchema } from './apartments.dto';
+import { AppDataSource } from '../config/data-source';
+import { Apartment } from '../entities/apartment.entity';
+import { ILike } from 'typeorm';
+
+const apartmentRepository = AppDataSource.getRepository(Apartment);
+
+export const getApartments = async (query: z.infer<typeof GetApartmentsRequestQuerySchema>) => {
+  const { name, address } = query;
+
+  const apartments = await apartmentRepository.find({
+    where: [name ? { name: ILike(`%${name}%`) } : {}, address ? { address: ILike(`%${address}%`) } : {}],
+    relations: ['users'],
+  });
+
+  const formattedApartments = apartments.map((apartment) => {
+    const admin = apartment.users.find((u) => u.id === apartment.adminId);
+
+    return {
+      id: apartment.id,
+      name: apartment.name,
+      address: apartment.address,
+      officeNumber: apartment.officeNumber,
+      description: apartment.description,
+      startComplexNumber: apartment.startComplexNumber,
+      endComplexNumber: apartment.endComplexNumber,
+      startDongNumber: apartment.startDongNumber,
+      endDongNumber: apartment.endDongNumber,
+      startFloorNumber: apartment.startFloorNumber,
+      endFloorNumber: apartment.endFloorNumber,
+      startHoNumber: apartment.startHoNumber,
+      endHoNumber: apartment.endHoNumber,
+      apartmentStatus: apartment.apartmentStatus,
+      adminId: admin?.id || null,
+      adminName: admin?.name || null,
+      adminContact: admin?.contact || null,
+      adminEmail: admin?.email || null,
+    };
+  });
+
+  return formattedApartments;
+};
+
+export const getApartment = async (params: z.infer<typeof ApartmentsRequestParamsSchema>) => {
+  const { id } = params;
+
+  const apartment = await apartmentRepository.findOne({
+    where: { id },
+    relations: ['users'],
+  });
+
+  if (!apartment) {
+    return null;
+  }
+
+  const admin = apartment.users.find((u) => u.id === apartment.adminId);
+
+  return {
+    id: apartment.id,
+    name: apartment.name,
+    address: apartment.address,
+    officeNumber: apartment.officeNumber,
+    description: apartment.description,
+    startComplexNumber: apartment.startComplexNumber,
+    endComplexNumber: apartment.endComplexNumber,
+    startDongNumber: apartment.startDongNumber,
+    endDongNumber: apartment.endDongNumber,
+    startFloorNumber: apartment.startFloorNumber,
+    endFloorNumber: apartment.endFloorNumber,
+    startHoNumber: apartment.startHoNumber,
+    endHoNumber: apartment.endHoNumber,
+    apartmentStatus: apartment.apartmentStatus,
+    adminId: admin?.id || null,
+    adminName: admin?.name || null,
+    adminContact: admin?.contact || null,
+    adminEmail: admin?.email || null,
+  };
+};

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,11 +6,19 @@ import root from './root/root.router';
 import { globalErrorHandler } from './handler/global-error.handler';
 import auth from './auth/auth.router';
 import resident from './residents/resident.router';
+import apartments from './apartments/apartments.router';
+import env from './config/env';
+import notifications from './notofications/notifications.router';
 
 const app: Application = express();
 
 // 미들웨어
-app.use(cors());
+app.use(
+  cors({
+    origin: env.CORS_ORIGIN,
+    credentials: true,
+  })
+);
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(cookieParser());
@@ -18,6 +26,8 @@ app.use(cookieParser());
 app.use('/api', root);
 app.use('/api/auth', auth);
 app.use('/api/residents', resident);
+app.use('/api/apartments', apartments);
+app.use('/api/notifications', notifications);
 
 app.use(notFoundHandler);
 app.use(globalErrorHandler);

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -5,7 +5,7 @@ import {
   LogoutRequestSchema,
   RefreshRequestSchema,
   RefreshResponseSchema,
-  SignupAdminRequestSchema,
+  SignupAdminRequestBodySchema,
   SignupAdminResponseSchema,
   SignupRequestSchema,
   SignupResponseSchema,
@@ -55,12 +55,15 @@ export const handleSignup: RequestHandler = async (req, res) => {
 };
 
 export const handleSignupAdmin: RequestHandler = async (req, res) => {
-  const result = SignupAdminRequestSchema.safeParse(req);
-  if (!result.success) {
+  const body = SignupAdminRequestBodySchema.safeParse(req.body);
+  if (!body.success) {
+    console.error(body.error.format());
     return new BadRequestError('잘못된 요청(필수사항 누락 또는 잘못된 입력값)입니다.');
   }
 
-  const signedupUser = await signupAdmin(result.data.body);
+  console.log(body);
+
+  const signedupUser = await signupAdmin(body.data);
 
   const response: z.infer<typeof SignupAdminResponseSchema> = {
     id: signedupUser.id,
@@ -70,6 +73,7 @@ export const handleSignupAdmin: RequestHandler = async (req, res) => {
     joinStatus: signedupUser.joinStatus,
     isActive: signedupUser.isActive,
   };
+  console.log('Admin signed up:', response);
   res.status(201).json(response);
 };
 

--- a/src/auth/auth.dto.ts
+++ b/src/auth/auth.dto.ts
@@ -24,14 +24,14 @@ const apartmentHo = z.string().min(1).max(8);
 const isActive = z.boolean();
 const description = z.string().min(1).max(256);
 const avatar = z.url().nullable();
-const startComplexNumber = z.number().int().min(1).max(999);
-const endComplexNumber = z.number().int().min(1).max(999);
-const startDongNumber = z.number().int().min(1).max(999);
-const endDongNumber = z.number().int().min(1).max(999);
-const startFloorNumber = z.number().int().min(1).max(999);
-const endFloorNumber = z.number().int().min(1).max(999);
-const startHoNumber = z.number().int().min(1).max(999);
-const endHoNumber = z.number().int().min(1).max(999);
+const startComplexNumber = z.string().min(1).max(8);
+const endComplexNumber = z.string().min(1).max(8);
+const startDongNumber = z.string().min(1).max(8);
+const endDongNumber = z.string().min(1).max(8);
+const startFloorNumber = z.string().min(1).max(8);
+const endFloorNumber = z.string().min(1).max(8);
+const startHoNumber = z.string().min(1).max(8);
+const endHoNumber = z.string().min(1).max(8);
 const apartmentAddress = z.string().min(1).max(512);
 const apartmentManagementNumber = z.string().min(1).max(11);
 const apartmentId = z.uuid().nullable();
@@ -55,6 +55,7 @@ export const AuthRequestParamsSchema = z.object({
 export const SignupRequestBodySchema = z.object({
   username: username,
   password: password,
+  passwordConfirm: password,
   contact: contact,
   name: name,
   email: email,
@@ -80,6 +81,7 @@ export const SignupResponseSchema = z.object({
 export const SignupAdminRequestBodySchema = z.object({
   username: username,
   password: password,
+  passwordConfirm: password,
   contact: contact,
   name: name,
   email: email,
@@ -96,10 +98,6 @@ export const SignupAdminRequestBodySchema = z.object({
   apartmentName: apartmentName,
   apartmentAddress: apartmentAddress,
   apartmentManagementNumber: apartmentManagementNumber,
-});
-
-export const SignupAdminRequestSchema = z.object({
-  body: SignupAdminRequestBodySchema,
 });
 
 export const SignupAdminResponseSchema = z.object({

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -20,6 +20,9 @@ interface Env {
   JWT_REFRESH_SECRET: string;
   JWT_ACCESS_EXPIRATION: number;
   JWT_REFRESH_EXPIRATION: number;
+
+  // CORS
+  CORS_ORIGIN: string;
 }
 
 const env: Env = {
@@ -42,6 +45,9 @@ const env: Env = {
   JWT_REFRESH_SECRET: process.env.JWT_REFRESH_SECRET || '',
   JWT_ACCESS_EXPIRATION: parseInt(process.env.JWT_ACCESS_EXPIRATION || '900000', 10),
   JWT_REFRESH_EXPIRATION: parseInt(process.env.JWT_REFRESH_EXPIRATION || '86400000', 10),
+
+  // CORS
+  CORS_ORIGIN: process.env.CORS_ORIGIN || 'http://localhost:3000',
 };
 
 if (!env.DB_HOST) throw new Error('Missing DB_HOST in environment variables');
@@ -50,5 +56,6 @@ if (!env.DB_PASSWORD) throw new Error('Missing DB_PASSWORD in environment variab
 if (!env.DB_NAME) throw new Error('Missing DB_NAME in environment variables');
 if (!env.JWT_ACCESS_SECRET) throw new Error('Missing JWT_ACCESS_SECRET in environment variables');
 if (!env.JWT_REFRESH_SECRET) throw new Error('Missing JWT_REFRESH_SECRET in environment variables');
+if (!env.CORS_ORIGIN) throw new Error('Missing CORS_ORIGIN in environment variables');
 
 export default env;

--- a/src/entities/apartment.entity.ts
+++ b/src/entities/apartment.entity.ts
@@ -75,8 +75,12 @@ export class Apartment {
   @OneToMany(() => User, (user) => user.apartment)
   users!: User[];
 
-  @OneToMany(() => User, (user) => user.apartment)
-  admins!: User[];
+  // 아파트 관리자는 한 명으로 추측
+  // @OneToMany(() => User, (user) => user.apartment)
+  // admins!: User[];
+
+  @Column()
+  adminId!: string;
 
   @OneToOne(() => NoticeBoard, (noticeBoard) => noticeBoard.apartment)
   noticeBoard!: NoticeBoard;

--- a/src/entities/complaint.entity.ts
+++ b/src/entities/complaint.entity.ts
@@ -7,48 +7,50 @@ import {
   ManyToOne,
   // OneToMany,
   JoinColumn,
-} from "typeorm";
-import { User } from "./user.entity";
-import { ComplaintBoard } from "./complaint-board.entity";
+  OneToMany,
+} from 'typeorm';
+import { User } from './user.entity';
+import { ComplaintBoard } from './complaint-board.entity';
+import { Notification } from './notification.entity';
 // import { Comment } from "./comment.entity";
 
-export type ComplaintStatus = "PENDING" | "IN_PROGRESS" | "RESOLVED";
+export type ComplaintStatus = 'PENDING' | 'IN_PROGRESS' | 'RESOLVED';
 
-@Entity({ name: "complaints" })
+@Entity({ name: 'complaints' })
 export class Complaint {
-  @PrimaryGeneratedColumn("uuid")
+  @PrimaryGeneratedColumn('uuid')
   complaintId!: string;
 
-  @ManyToOne(() => User, (user) => user.complaints, { onDelete: "CASCADE" })
-  @JoinColumn({ name: "user_id" })
+  @ManyToOne(() => User, (user) => user.complaints, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
   user!: User;
 
-  @Column({ type: "uuid" })
+  @Column({ type: 'uuid' })
   userId!: string;
 
   @ManyToOne(() => ComplaintBoard, (board) => board.complaints, {
     nullable: true,
-    onDelete: "SET NULL",
+    onDelete: 'SET NULL',
   })
-  @JoinColumn({ name: "board_id" })
+  @JoinColumn({ name: 'board_id' })
   complaintBoard!: ComplaintBoard | null;
 
-  @Column({ type: "uuid", nullable: true })
+  @Column({ type: 'uuid', nullable: true })
   boardId!: string | null;
 
   @Column({ length: 100 })
   title!: string;
 
-  @Column({ type: "text" })
+  @Column({ type: 'text' })
   content!: string;
 
   @Column({ default: true })
   isPublic!: boolean;
 
   @Column({
-    type: "enum",
-    enum: ["PENDING", "IN_PROGRESS", "RESOLVED"],
-    default: "PENDING",
+    type: 'enum',
+    enum: ['PENDING', 'IN_PROGRESS', 'RESOLVED'],
+    default: 'PENDING',
   })
   status!: ComplaintStatus;
 
@@ -67,9 +69,12 @@ export class Complaint {
   // @OneToMany(() => Comment, (comment) => comment.complaint)
   // comments!: Comment[];
 
-  @CreateDateColumn({ name: "created_at" })
+  @CreateDateColumn({ name: 'created_at' })
   createdAt!: Date;
 
-  @UpdateDateColumn({ name: "updated_at" })
+  @UpdateDateColumn({ name: 'updated_at' })
   updatedAt!: Date;
+
+  @OneToMany(() => Notification, (notification) => notification.complaint)
+  notifications!: Notification[];
 }

--- a/src/entities/notification.entity.ts
+++ b/src/entities/notification.entity.ts
@@ -1,0 +1,67 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, OneToMany, ManyToOne, JoinColumn } from 'typeorm';
+import { UserNotification } from './user-notification.entity';
+import { Complaint } from './complaint.entity';
+import { Poll } from './poll.entity';
+
+export enum NotificationType {
+  GENERAL = 'GENERAL',
+  SIGNUP_REQ = 'SIGNUP_REQ',
+  COMPLAINT_REQ = 'COMPLAINT_REQ',
+  COMPLAINT_IN_PROGRESS = 'COMPLAINT_IN_PROGRESS',
+  COMPLAINT_RESOLVED = 'COMPLAINT_RESOLVED',
+  COMPLAINT_REJECTED = 'COMPLAINT_REJECTED',
+  NOTICE_REG = 'NOTICE_REG',
+  POLL_REG = 'POLL_REG',
+  POLL_CLOSED = 'POLL_CLOSED',
+  POLL_RESULT = 'POLL_RESULT',
+  SYSTEM = 'SYSTEM',
+  TEST = 'TEST',
+}
+
+@Entity('notifications')
+export class Notification {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'enum', enum: NotificationType })
+  type!: NotificationType;
+
+  @Column()
+  content!: string;
+
+  @CreateDateColumn()
+  notifiedAt!: Date;
+
+  @Column({ nullable: true })
+  complaintId?: string;
+
+  @ManyToOne(() => Complaint, (complaint) => complaint.notifications, {
+    nullable: true,
+    onDelete: 'SET NULL',
+  })
+  @JoinColumn({ name: 'complaintId' })
+  complaint?: Complaint;
+
+  @Column({ nullable: true })
+  noticeId?: string;
+
+  /* @ManyToOne(() => Notice, (notice) => notice.notifications, {
+    nullable: true,
+    onDelete: 'SET NULL',
+  })
+  @JoinColumn({ name: 'noticeId' })
+  notice?: Notice; */
+
+  @Column({ nullable: true })
+  pollId?: string;
+
+  @ManyToOne(() => Poll, (poll) => poll.notifications, {
+    nullable: true,
+    onDelete: 'SET NULL',
+  })
+  @JoinColumn({ name: 'pollId' })
+  poll?: Poll;
+
+  @OneToMany(() => UserNotification, (userNotification) => userNotification.notification)
+  userNotifications!: UserNotification[];
+}

--- a/src/entities/poll.entity.ts
+++ b/src/entities/poll.entity.ts
@@ -7,20 +7,21 @@ import {
   JoinColumn,
   CreateDateColumn,
   UpdateDateColumn,
-} from "typeorm";
-import { PollOption } from "./poll-option.entity";
-import { User } from "./user.entity";
+} from 'typeorm';
+import { PollOption } from './poll-option.entity';
+import { User } from './user.entity';
+import { Notification } from './notification.entity';
 
-@Entity("polls")
+@Entity('polls')
 export class Poll {
-  @PrimaryGeneratedColumn("uuid")
+  @PrimaryGeneratedColumn('uuid')
   pollId!: string;
 
   @Column()
   boardId!: string;
 
   @ManyToOne(() => User, (user) => user.polls)
-  @JoinColumn({ name: "userId" })
+  @JoinColumn({ name: 'userId' })
   user!: User;
 
   @Column()
@@ -29,7 +30,7 @@ export class Poll {
   @Column()
   title!: string;
 
-  @Column("text")
+  @Column('text')
   content!: string;
 
   @Column()
@@ -38,18 +39,18 @@ export class Poll {
   @Column({ nullable: true })
   buildingPermission?: string;
 
-  @Column("timestamp")
+  @Column('timestamp')
   startDate!: Date;
 
-  @Column("timestamp")
+  @Column('timestamp')
   endDate!: Date;
 
   @Column({
-    type: "enum",
-    enum: ["IN_PROGRESS", "PENDING", "COMPLETED"],
-    default: "PENDING",
+    type: 'enum',
+    enum: ['IN_PROGRESS', 'PENDING', 'COMPLETED'],
+    default: 'PENDING',
   })
-  status!: "IN_PROGRESS" | "PENDING" | "COMPLETED";
+  status!: 'IN_PROGRESS' | 'PENDING' | 'COMPLETED';
 
   @CreateDateColumn()
   createdAt!: Date;
@@ -60,4 +61,7 @@ export class Poll {
   @OneToMany(() => PollOption, (option) => option.poll, { cascade: true })
   options!: PollOption[];
   pollBoard: any;
+
+  @OneToMany(() => Notification, (notification) => notification.poll)
+  notifications!: Notification[];
 }

--- a/src/entities/resident.entity.ts
+++ b/src/entities/resident.entity.ts
@@ -8,10 +8,10 @@ import {
   ManyToOne,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
-  DeleteDateColumn
-} from "typeorm";
-import { User } from "./user.entity";
-import { Apartment } from "./apartment.entity";
+  DeleteDateColumn,
+} from 'typeorm';
+import { User } from './user.entity';
+import { Apartment } from './apartment.entity';
 
 export enum ResidentStatus {
   RESIDENCE = 'RESIDENCE',
@@ -65,20 +65,18 @@ export class Resident {
   @Column({ default: false, comment: '위리브 가입 여부' })
   isRegistered!: boolean;
 
-  @OneToOne(() => User, user => user.resident, {
+  @OneToOne(() => User, (user) => user.resident, {
     cascade: true,
     nullable: true,
     onDelete: 'CASCADE',
   })
-
   @JoinColumn()
   user?: User | null;
 
-  @ManyToOne(() => Apartment, apartment => apartment.residents, {
+  @ManyToOne(() => Apartment, (apartment) => apartment.residents, {
     onDelete: 'CASCADE',
     nullable: false,
   })
-
   @JoinColumn({ name: 'apartmentId' })
   apartment!: Apartment;
 

--- a/src/entities/user-notification.entity.ts
+++ b/src/entities/user-notification.entity.ts
@@ -1,0 +1,18 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
+import { User } from './user.entity';
+import { Notification } from './notification.entity';
+
+@Entity('user_notifications')
+export class UserNotification {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @ManyToOne(() => User, (user) => user.userNotifications, { onDelete: 'CASCADE' })
+  user!: User;
+
+  @ManyToOne(() => Notification, (notification) => notification.userNotifications, { onDelete: 'CASCADE' })
+  notification!: Notification;
+
+  @Column({ default: false })
+  isChecked!: boolean;
+}

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -14,6 +14,8 @@ import { Apartment } from './apartment.entity';
 import { Resident } from './resident.entity';
 import { Complaint } from './complaint.entity';
 import { Vote } from './vote.entity';
+import { Poll } from './poll.entity';
+import { UserNotification } from './user-notification.entity';
 
 // =
 // : 사용자
@@ -75,23 +77,26 @@ export class User {
   @JoinColumn({ name: 'apartmentId' })
   apartment?: Apartment;
 
-  @Column()
+  @Column({ nullable: true })
   apartmentId?: string;
 
   @OneToMany(() => Complaint, (complaint) => complaint.user)
   complaints!: Complaint[];
 
-  // @OneToMany(() => Notice, (notice) => notice.user)
-  // notices!: Notice[];
+  //@OneToMany(() => Notice, (notice) => notice.user)
+  //notices!: Notice[];
 
-  // @OneToMany(() => Poll, (poll) => poll.user)
-  // polls!: Poll[];
+  @OneToMany(() => Poll, (poll) => poll.user)
+  polls!: Poll[];
 
-  // @OneToMany(() => Vote, (vote) => vote.user)
-  // votes!: Vote[];
+  @OneToMany(() => Vote, (vote) => vote.user)
+  votes!: Vote[];
 
-//   @OneToMany(() => Comment, (comment) => comment.user)
-//   comments!: Comment[];
+  //   @OneToMany(() => Comment, (comment) => comment.user)
+  //   comments!: Comment[];
+
+  @OneToMany(() => UserNotification, (userNotification) => userNotification.user)
+  userNotifications!: UserNotification[];
 
   @CreateDateColumn()
   createdAt!: Date;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,15 @@ import app from './app';
 import env from './config/env';
 import { initSocket } from './ws/socket';
 import { AppDataSource } from './config/data-source';
+import { seed } from './seeds';
 
 const server = http.createServer(app);
 
 AppDataSource.initialize()
-  .then(() => {
+  .then(async () => {
     console.log('Database connected');
+
+    await seed();
 
     initSocket(server);
 

--- a/src/migrations/1758673768779-AutoMigration.ts
+++ b/src/migrations/1758673768779-AutoMigration.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AutoMigration1758673768779 implements MigrationInterface {
+    name = 'AutoMigration1758673768779'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "users" DROP CONSTRAINT "FK_a0e2e451cd46b8db454758a81e3"`);
+        await queryRunner.query(`CREATE TYPE "public"."residents_ishouseholder_enum" AS ENUM('HOUSEHOLDER', 'MEMBER')`);
+        await queryRunner.query(`CREATE TYPE "public"."residents_residentstatus_enum" AS ENUM('RESIDENCE', 'NO_RESIDENCE')`);
+        await queryRunner.query(`CREATE TABLE "residents" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" character varying(50) NOT NULL, "contact" character varying(20) NOT NULL, "building" character varying(10) NOT NULL, "unitNumber" character varying(10) NOT NULL, "isHouseholder" "public"."residents_ishouseholder_enum" NOT NULL DEFAULT 'MEMBER', "residentStatus" "public"."residents_residentstatus_enum" NOT NULL DEFAULT 'RESIDENCE', "isRegistered" boolean NOT NULL DEFAULT false, "apartmentId" uuid NOT NULL, "deletedAt" TIMESTAMP, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "userId" uuid, CONSTRAINT "REL_3b7ff30eaf080e784c2a3492f3" UNIQUE ("userId"), CONSTRAINT "PK_4c8d0413ee0e9a4ebbf500f7365" PRIMARY KEY ("id")); COMMENT ON COLUMN "residents"."name" IS '입주민 이름'; COMMENT ON COLUMN "residents"."contact" IS '연락처'; COMMENT ON COLUMN "residents"."building" IS '동'; COMMENT ON COLUMN "residents"."unitNumber" IS '호수'; COMMENT ON COLUMN "residents"."isHouseholder" IS '세대 여부'; COMMENT ON COLUMN "residents"."residentStatus" IS '거주 여부'; COMMENT ON COLUMN "residents"."isRegistered" IS '위리브 가입 여부'`);
+        await queryRunner.query(`CREATE INDEX "IDX_8fdb25e18fd6f60567a190ae31" ON "residents" ("name") `);
+        await queryRunner.query(`CREATE INDEX "IDX_76663b0dfb9bc282d88f8b6e63" ON "residents" ("contact") `);
+        await queryRunner.query(`CREATE INDEX "IDX_8beb11a2fc9db8b5c6b9755f6f" ON "residents" ("building") `);
+        await queryRunner.query(`CREATE INDEX "IDX_203994944fd0974433d2354697" ON "residents" ("unitNumber") `);
+        await queryRunner.query(`ALTER TABLE "residents" ADD CONSTRAINT "FK_3b7ff30eaf080e784c2a3492f32" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "residents" ADD CONSTRAINT "FK_c27986c3d64e11354652e942846" FOREIGN KEY ("apartmentId") REFERENCES "apartments"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "users" ADD CONSTRAINT "FK_a0e2e451cd46b8db454758a81e3" FOREIGN KEY ("residentId") REFERENCES "residents"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "users" DROP CONSTRAINT "FK_a0e2e451cd46b8db454758a81e3"`);
+        await queryRunner.query(`ALTER TABLE "residents" DROP CONSTRAINT "FK_c27986c3d64e11354652e942846"`);
+        await queryRunner.query(`ALTER TABLE "residents" DROP CONSTRAINT "FK_3b7ff30eaf080e784c2a3492f32"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_203994944fd0974433d2354697"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_8beb11a2fc9db8b5c6b9755f6f"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_76663b0dfb9bc282d88f8b6e63"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_8fdb25e18fd6f60567a190ae31"`);
+        await queryRunner.query(`DROP TABLE "residents"`);
+        await queryRunner.query(`DROP TYPE "public"."residents_residentstatus_enum"`);
+        await queryRunner.query(`DROP TYPE "public"."residents_ishouseholder_enum"`);
+        await queryRunner.query(`ALTER TABLE "users" ADD CONSTRAINT "FK_a0e2e451cd46b8db454758a81e3" FOREIGN KEY ("residentId") REFERENCES "Resident"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+}

--- a/src/migrations/1758674471016-AutoMigration.ts
+++ b/src/migrations/1758674471016-AutoMigration.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AutoMigration1758674471016 implements MigrationInterface {
+    name = 'AutoMigration1758674471016'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "apartments" ADD "adminId" character varying NOT NULL`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "apartments" DROP COLUMN "adminId"`);
+    }
+
+}

--- a/src/migrations/1758675387461-AutoMigration.ts
+++ b/src/migrations/1758675387461-AutoMigration.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AutoMigration1758675387461 implements MigrationInterface {
+    name = 'AutoMigration1758675387461'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "users" DROP CONSTRAINT "FK_108456969a2cb5d24d7f2541049"`);
+        await queryRunner.query(`ALTER TABLE "users" ALTER COLUMN "apartmentId" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "users" ADD CONSTRAINT "FK_108456969a2cb5d24d7f2541049" FOREIGN KEY ("apartmentId") REFERENCES "apartments"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "users" DROP CONSTRAINT "FK_108456969a2cb5d24d7f2541049"`);
+        await queryRunner.query(`ALTER TABLE "users" ALTER COLUMN "apartmentId" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "users" ADD CONSTRAINT "FK_108456969a2cb5d24d7f2541049" FOREIGN KEY ("apartmentId") REFERENCES "apartments"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+}

--- a/src/notofications/notifications.controller.ts
+++ b/src/notofications/notifications.controller.ts
@@ -1,0 +1,34 @@
+import { RequestHandler } from 'express';
+import { getNotifications } from './notifications.service';
+import { getUser } from '../utils/user.util';
+
+export const handleGetNotifications: RequestHandler = async (req, res) => {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.flushHeaders();
+
+  const user = getUser(req);
+
+  const intervalId = setInterval(async () => {
+    try {
+      const notifications = await getNotifications(user.id);
+
+      const payload = {
+        type: 'alarm',
+        data: notifications,
+      };
+
+      res.write(`event: alarm\n`);
+      res.write(`data: ${JSON.stringify(payload)}\n\n`);
+    } catch (err) {
+      res.write(`event: error\n`);
+      res.write(`data: ${JSON.stringify({ message: 'Failed to fetch notifications' })}\n\n`);
+    }
+  }, 5000);
+
+  req.on('close', () => {
+    clearInterval(intervalId);
+    console.log(`SSE connection closed for user ${user.id}`);
+  });
+};

--- a/src/notofications/notifications.router.ts
+++ b/src/notofications/notifications.router.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { allow, AllowedRole } from '../middlewares/allow.middleware';
+import { handleGetNotifications } from './notifications.controller';
+
+const notifications = Router();
+
+notifications.get('/sse', allow(AllowedRole.USER), handleGetNotifications);
+
+export default notifications;

--- a/src/notofications/notifications.service.ts
+++ b/src/notofications/notifications.service.ts
@@ -1,0 +1,23 @@
+import { AppDataSource } from '../config/data-source';
+import { UserNotification } from '../entities/user-notification.entity';
+
+const userNotificationRepository = AppDataSource.getRepository(UserNotification);
+
+export const getNotifications = async (userId: string) => {
+  const userNotifications = await userNotificationRepository.find({
+    where: { user: { id: userId }, isChecked: false },
+    relations: ['notification'],
+    order: { notification: { notifiedAt: 'DESC' } },
+  });
+
+  return userNotifications.map((un: UserNotification) => ({
+    notificationId: un.notification.id,
+    content: un.notification.content,
+    notificationType: un.notification.type,
+    notifiedAt: un.notification.notifiedAt.toISOString(),
+    isChecked: un.isChecked,
+    complaintId: un.notification.complaintId,
+    noticeId: un.notification.noticeId,
+    pollId: un.notification.pollId,
+  }));
+};

--- a/src/seeds/index.ts
+++ b/src/seeds/index.ts
@@ -1,0 +1,7 @@
+import 'reflect-metadata';
+import { AppDataSource } from '../config/data-source';
+import { seedUsers } from './user.seed';
+
+export const seed = async () => {
+  await seedUsers(AppDataSource);
+};

--- a/src/seeds/user.seed.ts
+++ b/src/seeds/user.seed.ts
@@ -1,0 +1,27 @@
+import { DataSource } from 'typeorm';
+import { User, UserRole, JoinStatus } from '../entities/user.entity';
+import * as bcrypt from 'bcrypt';
+
+export async function seedUsers(dataSource: DataSource) {
+  const repo = dataSource.getRepository(User);
+
+  // SuperAdmin 계정 확인
+  const exists = await repo.findOne({ where: { username: 'superadmin' } });
+  if (!exists) {
+    const hashedPassword = await bcrypt.hash('superadmin1234!', 10);
+    const superAdmin = repo.create({
+      username: 'superadmin',
+      password: hashedPassword,
+      name: '홍길동',
+      email: 'superadmin@example.com',
+      contact: '010-0000-0000',
+      role: UserRole.SUPER_ADMIN,
+      joinStatus: JoinStatus.APPROVED,
+      isActive: true,
+    });
+    await repo.save(superAdmin);
+    console.log('SuperAdmin seeded');
+  } else {
+    console.log('SuperAdmin already exists');
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,9 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "emitDecoratorMetadata": true
+    "emitDecoratorMetadata": true,
+    "types": ["node", "express"],
+    "typeRoots": ["./src/types", "./node_modules/@types"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## 연관된 이슈
Closes #59 

## 작업 내용
### Apartments API
회원가입시 필요한 아파트  목록을 가져오는 API 가 추가 되었습니다.

> /apartments
> /apartments/:id

### Notifications API
SuperAdmin 으로 로그인 했을 때 받아오는 `/notifications/sse` 를 추가합니다.

### Notification 엔티티 추가
Notification 을 데이터베이스에 추가하기 위한 엔티티를 추가합니다.

@singnyeo 
각각의 Complaint 가 진행 상태에 따라서 여러 알림을 가지기 때문에 관계성이 추가되었습니다.

@JONGJIN-LEE1 
각각의 Poll 이 진행 상태에 따라서 여러 알림을 가지기 때문에 관계성이 추가되었습니다.

### UserNotification 엔티티 추가
User 와 Notification 을 연결하기 위한 링크 엔티티가 추가되었습니다.

### Seed 추가
서버가 실행될 때 기본  SuperAdmin 을 추가하는 시드가 추가되었습니다.

> username : superadmin
> passowrd : superadmin1234!

### 프론트 코드 수정
프론트가 여전히 API 명세서와 맞지 않는 부분이 있습니다.

Notification[] 을 받아올 때 API 명세서에서는 아래와 같이 보내라고 되어있는 반면,

```json
{
  "type": "alarm",
  "data": [
    {
      "notificationId": "uuid-1234",
      "content": "민원 처리가 완료되었습니다.",
      "notificationType": "COMPLAINT_RESOLVED",
      "notifiedAt": "2025-06-13T12:34:56.789Z",
      "isChecked": false,
      "complaintId": "complaint-uuid-9876",
      "noticeId": "notice-uuid-1111",
      "pollId": "poll-uuid-2222"
    }
  ]
}
```

프론트에서는 저 json 전체를 배열로 인식하고 받아들이려고 하고 있습니다.

고로, API 명세서에 따라서 `data` 에 있는 Notification[] 만 받도록 프론트 코드 수정이 필요합니다.

**src/shared/Navibar.tsx**
```typescript
// LINE 79
const parsed = JSON.parse(event.data);
const newNotifications: Notification[] = parsed.data || [];
```

## 테스트
위의 시드 계정으로 프론트에서 로그인이 가능합니다.

<img width="1899" height="961" alt="스크린샷 2025-09-24 오후 1 17 29" src="https://github.com/user-attachments/assets/a738e07a-6f0c-468e-a7a3-41273b52ffb9" />
