### PR TITLE
feat: resident 승낙/거절 API 추가

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -11,7 +11,7 @@ import env from './config/env';
 import notifications from './notofications/notifications.router';
 import pollsRouter from './polls/polls.router';
 import users from './users/users.router';
-import complaint from "./complaint/complaint.router";
+import complaint from './complaint/complaint.router';
 const app: Application = express();
 
 // 미들웨어
@@ -27,7 +27,7 @@ app.use(cookieParser());
 
 app.use('/api', root);
 app.use('/api/auth', auth);
-app.use('/residents', resident);
+app.use('/api/residents', resident);
 app.use('/api/apartments', apartments);
 app.use('/api/complaints', complaint);
 app.use('/api/notifications', notifications);

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -15,6 +15,7 @@ import {
   UpdateAdminRequestSchema,
   UpdateAdminsStatusRequestSchema,
   UpdateAdminStatusRequestSchema,
+  UpdateResidentsStatusRequestSchema,
 } from './auth.dto';
 import { BadRequestError, UnauthorizedError } from '../types/error.type';
 import {
@@ -31,6 +32,8 @@ import {
   updateAdmin,
   updateAdminsStatus,
   updateAdminStatus,
+  updateResidentsStatus,
+  updateResidentStatus,
 } from './auth.service';
 import z from 'zod';
 import {
@@ -251,12 +254,38 @@ export const handleUpdateAdminsStatus: RequestHandler = async (req, res) => {
   res.status(200).send({ message: '작업이 성공적으로 완료되었습니다' });
 };
 
-export const handleUpdateResidentStatus: RequestHandler = (_req, res) => {
-  res.status(200).send('handleUpdateResidentStatus');
+export const handleUpdateResidentStatus: RequestHandler = async (req, res) => {
+  const result = UpdateAdminStatusRequestSchema.safeParse({
+    params: req.params,
+    body: req.body,
+  });
+
+  if (!result.success) {
+    throw new BadRequestError('잘못된 요청(필수사항 누락 또는 잘못된 입력값)입니다');
+  }
+
+  const { id } = result.data.params;
+  const { status } = result.data.body;
+
+  await updateResidentStatus(id, status);
+
+  res.status(200).send({ message: '작업이 성공적으로 완료되었습니다' });
 };
 
-export const handleUpdateResidentsStatus: RequestHandler = (_req, res) => {
-  res.status(200).send('handleUpdateResidentsStatus');
+export const handleUpdateResidentsStatus: RequestHandler = async (req, res) => {
+  const result = UpdateResidentsStatusRequestSchema.safeParse({
+    body: req.body,
+  });
+
+  if (!result.success) {
+    throw new BadRequestError('잘못된 요청(필수사항 누락 또는 잘못된 입력값)입니다');
+  }
+
+  const { status } = result.data.body;
+
+  await updateResidentsStatus(status);
+
+  res.status(200).send({ message: '작업이 성공적으로 완료되었습니다' });
 };
 
 export const handleUpdateAdmin: RequestHandler = async (req, res) => {

--- a/src/auth/auth.dto.ts
+++ b/src/auth/auth.dto.ts
@@ -201,16 +201,25 @@ export const UpdateAdminsStatusResponseSchema = z.object({
   message: message,
 });
 
-export const UpdateResidentStatusRequestSchema = z.object({
+export const UpdateResidentStatusRequestBodySchema = z.object({
   status: joinStatus,
+});
+
+export const UpdateResidentStatusRequestSchema = z.object({
+  params: UpdateAdminStatusRequestParamsSchema,
+  body: UpdateResidentStatusRequestBodySchema,
 });
 
 export const UpdateResidentStatusResponseSchema = z.object({
   message: message,
 });
 
-export const UpdateResidentsStatusRequestSchema = z.object({
+export const UpdateResidentsStatusRequestBodySchema = z.object({
   status: joinStatus,
+});
+
+export const UpdateResidentsStatusRequestSchema = z.object({
+  body: UpdateResidentsStatusRequestBodySchema,
 });
 
 export const UpdateResidentsStatusResponseSchema = z.object({

--- a/src/entities/resident.entity.ts
+++ b/src/entities/resident.entity.ts
@@ -12,7 +12,6 @@ import {
 } from 'typeorm';
 import { User } from './user.entity';
 import { Apartment } from './apartment.entity';
-import { ApprovalStatus } from './approvalStatus.entity';
 
 export enum ResidenceStatus {
   RESIDENCE = 'RESIDENCE',
@@ -92,12 +91,4 @@ export class Resident {
 
   @UpdateDateColumn()
   updatedAt!: Date;
-
-  @Column({
-    type: 'enum',
-    enum: ApprovalStatus,
-    default: ApprovalStatus.PENDING,
-    comment: '승인 상태',
-  })
-  approvalStatus!: ApprovalStatus;
 }


### PR DESCRIPTION
## 연관된 이슈
#173 

## 연관된 개발 내용
- `api.ts` 의 `/residents` 앞에 `/api` 접두어가 추가되었습니다.
- `user` 로부터 `joinStatus` 를 받아와서 처리하기 때문에 `resident.entity.ts` 에서 더 이상 필요없는 `approvalStatus` 가 삭제되었습니다.

## 작업 내용
- `/residents/:id/status`
- `/residents/status`

## 프론트 연동 테스트 결과
<img width="1899" height="793" alt="스크린샷 2025-10-23 오후 5 35 37" src="https://github.com/user-attachments/assets/155f9cea-0c89-423a-9b01-a7a650e22906" />
