### PR TITLE
fix :  notice 경로 수정 및 공지사항 삭제 유닛 테스트 통과

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,7 @@ import pollsRouter from "./polls/polls.router";
 import users from "./users/users.router";
 import complaint from "./complaint/complaint.router";
 import vote from "./votes/votes.router";
+import notice from "./notice/notice.router";
 
 const app: Application = express();
 
@@ -36,6 +37,7 @@ app.use("/api/notifications", notifications);
 app.use("/api/users", users);
 app.use("/api/polls", pollsRouter);
 app.use("/api/options", vote);
+app.use("/api/notices", notice)
 
 app.use(notFoundHandler);
 app.use(globalErrorHandler);

--- a/src/entities/notice.entity.ts
+++ b/src/entities/notice.entity.ts
@@ -67,7 +67,7 @@ export class Notice {
   @Column({ type: 'text', nullable: false })
   content!: string;
 
-  @Column({ type: 'int', nullable: false })
+  @Column({ type: 'int', default: 0, nullable: false })
   viewsCount!: number;
 
   @OneToMany(() => Comment, (c) => c.notice)
@@ -96,6 +96,7 @@ export class Comment {
   content!: string;
 
   @ManyToOne(() => Notice, (notice) => notice.comments, { onDelete: 'CASCADE' })
+
   @JoinColumn({ name: 'noticeId' })
   notice!: Notice;
 

--- a/src/notice/dto/create-notice.dto.ts
+++ b/src/notice/dto/create-notice.dto.ts
@@ -18,6 +18,7 @@ const FORBID_HTML = /[<>]/;
 /** 요청 바디 스키마 */
 export const CreateNoticeRequestSchema = z
   .object({
+    userId: z.string().uuid(),
     category: NoticeCategoryEnum,
     title: z.preprocess(
       trim,
@@ -34,8 +35,8 @@ export const CreateNoticeRequestSchema = z
       .refine((v) => !FORBID_HTML.test(v), "HTML 태그(<, >)는 허용되지 않습니다."),
     boardId: z.string().uuid("boardId는 UUID 형식이어야 합니다."),
     isPinned: z.boolean().optional().default(false),
-    startsAt: z.string().datetime().optional(), // ISO8601(UTC)
-    endsAt: z.string().datetime().optional(),   // ISO8601(UTC)
+    startDate: z.string().datetime().optional(), // ISO8601(UTC)
+    endDate: z.string().datetime().optional(),   // ISO8601(UTC)
   })
 
 export type CreateNoticeRequestDto = z.infer<typeof CreateNoticeRequestSchema>;

--- a/src/notice/dto/delete-notice.dto.ts
+++ b/src/notice/dto/delete-notice.dto.ts
@@ -1,9 +1,8 @@
 import { z } from 'zod';
 
-
 // 공지사항 삭제 요청 DTO
 export const DeleteNoticeRequestDto = z.object({
-    noticeId: z.string().uuid(),  // 삭제할 공지사항 고유 번호
+    noticeId: z.string(),
 });
 
 // 공지사항 삭제 응답 DTO

--- a/src/notice/notice.controller.ts
+++ b/src/notice/notice.controller.ts
@@ -45,6 +45,6 @@ export const DeleteNotice = async (req: Request, res: Response) => {
         noticeId: noticeId,
     });
 
-    await noticeService.DeleteNotice(Result);
-    return res.status(200).json({ message: '정상적으로 삭제 되었습니다.' });
+    const response = await noticeService.DeleteNotice(Result);
+    return res.status(200).json(response);
 };

--- a/src/notice/notice.service.ts
+++ b/src/notice/notice.service.ts
@@ -166,7 +166,6 @@ export const DeleteNotice = async (data: DeleteNoticeRequestDtoType) => {
         console.log(Notice)
         return DeleteNoticeResponseDto.parse({ message: "공지사항이 정상적으로 삭제 되었습니다." });
     } else {
-        // 삭제 대상이 없거나 실패한 경우 에러 처리 (예외 던지거나 메시지 반환)
         throw new Error("삭제할 공지사항이 존재하지 않습니다.");
     }
 };


### PR DESCRIPTION
## #️⃣연관된 이슈
#179 

## 📝작업 내용
notice 경로 수정 및 공지사항 삭제 유닛 테스트 완료 
통합 테스트 및 공지사항 댓글과 알림 API 구현은 추후에 작성 후 PR 올리겠습니다 

## 💡테스트 결과
공지사항 삭제 유닛 테스트 통과 함 
