### PR TITLE
fix: 공지사항 페이지네이션 수정 및 공지사항 댓글 요청 import 추가

### DIFF
--- a/src/notice/notice.controller.ts
+++ b/src/notice/notice.controller.ts
@@ -5,7 +5,7 @@ import * as noticeService from './notice.service'
 import { UpdateRequestSchema } from './dto/update-notice.request.dto'
 import { DeleteNoticeRequestDto } from './dto/delete-notice.dto'
 
-
+//공지사항 CRUD 
 export const CreateNotice = async (req: Request, res: Response) => {
     const Result = CreateNoticeRequestSchema.parse({
         userId: (req as any).user?.id,
@@ -48,3 +48,4 @@ export const DeleteNotice = async (req: Request, res: Response) => {
     const response = await noticeService.DeleteNotice(Result);
     return res.status(200).json(response);
 };
+

--- a/src/notice/notice.service.ts
+++ b/src/notice/notice.service.ts
@@ -10,23 +10,13 @@ import { NoticeListqueryDto } from "./dto/list-notice.query.dto";
 import { User } from "../entities/user.entity";
 import { NoticeDetailResponseDto } from "./dto/notifications-read.response.dto";
 import { _date } from "zod/v4/core";
-// import { CommentResponseDto } from './dto/create-comment.dto' // 파일 없어서 주석 처리
+import { CommentResponseDto } from '../notice/notice-comments/create-comment.response.dto' // 파일 없어서 주석 처리
 import { UpdateRequestDto } from "./dto/update-notice.request.dto";
 import { UpdateResponseSchema } from "./dto/update-notice.response.dto";
 import {
   DeleteNoticeRequestDtoType,
   DeleteNoticeResponseDto,
 } from "./dto/delete-notice.dto";
-
-// CommentResponseDto 타입 정의 (댓글 응답용) // create-comment.dto 파일이 없어서 여기에 정의함
-interface CommentResponseDto {
-  id: string;
-  userId: string;
-  writerName: string;
-  content: string;
-  createdAt: string;
-  updatedAt: string;
-}
 
 //공지사항 생성 서비스
 export const createNotice = async (data: CreateNoticeRequestDto) => {
@@ -69,7 +59,9 @@ export const ListNotice = async (
   query: NoticeListqueryDto
 ): Promise<NoticeListResponseDto> => {
   const noticeRepo = AppDataSource.getRepository(Notice);
-  const [notices, _] = await noticeRepo.findAndCount({
+
+  // ✅ totalCount 변수에 전체 개수 저장!
+  const [notices, totalCount] = await noticeRepo.findAndCount({
     skip: (query.page - 1) * query.limit,
     take: query.limit,
     where: [
@@ -111,9 +103,8 @@ export const ListNotice = async (
 
   const response: NoticeListResponseDto = {
     items: data,
-    totalCount: data.length,
+    totalCount: totalCount, // ✅ data.length → totalCount로 변경!
   };
-
   return response;
 };
 
@@ -214,3 +205,8 @@ export const DeleteNotice = async (data: DeleteNoticeRequestDtoType) => {
     throw new Error("삭제할 공지사항이 존재하지 않습니다.");
   }
 };
+
+
+
+
+


### PR DESCRIPTION
## #️⃣연관된 이슈
#209 

## 📝작업 내용
data.length는 현재 페이지의 items 개수(11개)만 반환하고 있는데,
실제로는 findAndCount의 두 번째 값(전체 개수)을 사용해야해서 변경했습니다 
CommentResponseDto import  추가 했습니다 


