### PR TITLE
fix: 공지사항 프론트에 맞춰 수정/ boardId 자동 설정 

### DIFF
--- a/src/notice/dto/create-notice.dto.ts
+++ b/src/notice/dto/create-notice.dto.ts
@@ -33,7 +33,7 @@ export const CreateNoticeRequestSchema = z
       .min(1, "내용은 1~200자여야 합니다.")
       .max(200, "내용은 1~200자여야 합니다.")
       .refine((v) => !FORBID_HTML.test(v), "HTML 태그(<, >)는 허용되지 않습니다."),
-    boardId: z.string().uuid("boardId는 UUID 형식이어야 합니다."),
+    boardId: z.string().uuid("boardId는 UUID 형식이어야 합니다.").nullable().optional(),
     isPinned: z.boolean().optional().default(false),
     startDate: z.string().datetime().optional(), // ISO8601(UTC)
     endDate: z.string().datetime().optional(),   // ISO8601(UTC)

--- a/src/notice/dto/list-notice.query.dto.ts
+++ b/src/notice/dto/list-notice.query.dto.ts
@@ -7,7 +7,8 @@ export const NoticeListquerySchema = z.object({
     page: z.coerce.number().int().min(1).default(1),
     limit: z.coerce.number().int().min(1).default(11),
     category: NoticeCategoryEnum.optional(),
-    search: z.string().optional()
+    search: z.string().optional(),
+    boardId: z.string().uuid().nullable().optional(),
 })
 export type NoticeListqueryDto = z.infer<typeof NoticeListquerySchema>;
 
@@ -20,7 +21,7 @@ export const NoticeListItemSchema = z.object({
     isPinned: z.boolean(),
     startDate: z.string().datetime().optional(),
     endDate: z.string().datetime().optional(),
-    boardId: z.string().uuid().optional(),
+    boardId: z.string().uuid().nullable().optional(),
 
     createdAt: z.string().datetime(),
     updatedAt: z.string().datetime(),
@@ -33,7 +34,7 @@ export type NoticeListItemDto = z.infer<typeof NoticeListItemSchema>;
 
 //목록 응답(래퍼) — items + totalCount 
 export const NoticeListResponseSchema = z.object({
-    items: z.array(NoticeListItemSchema),
+    notices: z.array(NoticeListItemSchema),
     totalCount: z.number().int().nonnegative(),
 });
 export type NoticeListResponseDto = z.infer<typeof NoticeListResponseSchema>;

--- a/src/notice/dto/notice-request.dto.ts
+++ b/src/notice/dto/notice-request.dto.ts
@@ -33,7 +33,7 @@ export const CreateNoticeRequestSchema = z
             .min(1, "내용은 1~200자여야 합니다.")
             .max(200, "내용은 1~200자여야 합니다.")
             .refine((v) => !FORBID_HTML.test(v), "HTML 태그(<, >)는 허용되지 않습니다."),
-        boardId: z.string().uuid("boardId는 UUID 형식이어야 합니다."),
+        boardId: z.string().uuid("boardId는 UUID 형식이어야 합니다.").nullable().optional(),
         isPinned: z.boolean().optional().default(false),
         startDate: z.string().datetime().optional(), // ISO8601(UTC)
         endDate: z.string().datetime().optional(),   // ISO8601(UTC)

--- a/src/notice/dto/update-notice.request.dto.ts
+++ b/src/notice/dto/update-notice.request.dto.ts
@@ -3,12 +3,12 @@ import { NoticeCategoryEnum } from "./notice-request.dto"
 
 export const UpdateRequestSchema = z.object({
     noticeId: z.string().uuid(),
-    userId: z.string().uuid(),
+    userId: z.string().uuid().optional(),
     category: NoticeCategoryEnum,
     title: z.string().trim().min(1, "제목은 1자 이상이어야 합니다."),
     content: z.string(),
     isPinned: z.boolean(),
-    boardId: z.string().uuid().optional(),
+    boardId: z.string().uuid().nullable().optional(),
     startDate: z.string().datetime().optional(), // ISO8601(UTC)
     endDate: z.string().datetime().optional(),   // ISO8601(UTC)
 });


### PR DESCRIPTION
## 📝작업 내용

이전 코드에서는 공지사항 생성 시 `boardId`를 요청 데이터에서 받아 처리했기 때문에, 프론트에서 `boardId`를 누락하면 공지 생성 과정에서 오류가 발생했습니다.

1. **게시판 ID 자동 설정**

   * 공지사항 생성/수정 시, 요청에서 `boardId`를 받지 않아도
     서버에서 **사용자 조회 → 아파트 ID 확인 → 해당 아파트의 게시판 ID 자동 조회** 후 설정하도록 로직 변경.
2. **DTO 개선**

   * `boardId`를 옵셔널/nullable로 변경
   * 프론트에서 전달하지 않아도 오류가 발생하지 않도록 개선.
   
 #### 사용자 아파트 정보를 기반으로 게시판 조회, 수정, 생성, 삭제 가능
####  `boardId` 누락 오류 방지

## 💡테스트 결과
<img width="782" height="354" alt="image" src="https://github.com/user-attachments/assets/19bf0901-7ab1-49e4-ad87-09acfc064159" />
<img width="782" height="346" alt="image" src="https://github.com/user-attachments/assets/d581f052-811b-417a-9eb9-ca58e58a465b" />
